### PR TITLE
Review 1/2 — core & CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "envault"
+version = "0.5.2"
+edition = "2021"
+description = "Local secrets vault for agentic coding: agents see aliases and ciphers, never plaintext"
+license = "MIT"
+
+[dependencies]
+age = { version = "0.11", features = ["armor"] }
+anyhow = "1"
+arboard = "3"
+base64 = "0.22"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
+crossterm = "0.28"
+dirs = "5"
+dotenvy = "0.15"
+portable-pty = "0.8"
+ratatui = "0.29"
+robius-authentication = "0.3.1"
+rpassword = "7"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+toml = "0.8"
+tungstenite = "0.24"
+ureq = { version = "2", features = ["json"] }
+url = "2"
+urlencoding = "2"
+
+# Secret store backend, per platform: Keychain (macOS), Credential Manager
+# (Windows), Secret Service (Linux).
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring = { version = "3", features = ["apple-native"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring = { version = "3", features = ["windows-native"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = "3"
+tungstenite = "0.24"

--- a/src/access.rs
+++ b/src/access.rs
@@ -1,0 +1,24 @@
+//! The single choke point for using the private key. Centralizes the Touch ID
+//! gate (when enabled) and audit logging, so every decryption path is covered
+//! consistently.
+
+use anyhow::Result;
+use std::path::Path;
+
+use crate::{audit, biometric, crypto, settings::Settings};
+
+/// Load the private key for a decryption, applying the configured gate and
+/// recording the access. `action` is a short verb (run/reveal/copy/fill/rotate)
+/// and `detail` is the command or alias involved.
+pub fn unlock(home: &Path, action: &str, detail: &str) -> Result<age::x25519::Identity> {
+    let s = Settings::load(home);
+    if s.touch_id {
+        biometric::require(&format!("Approve envault {action}: {detail}"))?;
+    }
+    let identity = crypto::load_identity()?;
+    if s.audit_log {
+        // Best-effort: a logging hiccup must not block the actual operation.
+        let _ = audit::record(home, action, detail);
+    }
+    Ok(identity)
+}

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,0 +1,171 @@
+//! Lightweight, hash-chained audit log of every decryption.
+//!
+//! Design goals: cheap (one line appended per event, no daemon), small
+//! (auto-trimmed to a size cap), and tamper-evident (each entry carries the
+//! previous entry's hash, so deletion or edits break the chain and show up in
+//! `verify`). It does not *prevent* misuse — it makes access visible.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+/// Keep the log tiny — trim to the most recent entries once it passes this.
+const MAX_BYTES: u64 = 256 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Entry {
+    pub ts: String,
+    pub action: String, // run | reveal | copy | fill | rotate
+    pub detail: String, // the command run, or the alias accessed
+    pub prev: String,   // hex hash of the previous entry ("" for the first)
+    pub hash: String,   // hex hash of this entry's (ts, action, detail, prev)
+}
+
+fn log_file(home: &Path) -> PathBuf {
+    home.join("audit.log")
+}
+
+fn hash_entry(ts: &str, action: &str, detail: &str, prev: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(ts.as_bytes());
+    h.update([0]);
+    h.update(action.as_bytes());
+    h.update([0]);
+    h.update(detail.as_bytes());
+    h.update([0]);
+    h.update(prev.as_bytes());
+    hex(&h.finalize())
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Append an event. Best-effort: a logging failure must never break the
+/// operation being logged, so errors are swallowed by the caller.
+pub fn record(home: &Path, action: &str, detail: &str) -> Result<()> {
+    let entries = read(home).unwrap_or_default();
+    let prev = entries.last().map(|e| e.hash.clone()).unwrap_or_default();
+    let ts = crate::store::now_rfc3339();
+    let hash = hash_entry(&ts, action, detail, &prev);
+    let entry = Entry {
+        ts,
+        action: action.to_string(),
+        detail: detail.to_string(),
+        prev,
+        hash,
+    };
+
+    let path = log_file(home);
+    std::fs::create_dir_all(home)?;
+    let mut line = serde_json::to_string(&entry)?;
+    line.push('\n');
+
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    f.write_all(line.as_bytes())?;
+    drop(f);
+    crate::platform::set_mode(&path, 0o600)?;
+
+    trim(home)?;
+    Ok(())
+}
+
+/// Trim the oldest lines once the file grows past the cap, keeping the log
+/// small. (The chain's first retained entry then references a dropped one —
+/// that's a normal rotation boundary, distinct from tampering.)
+fn trim(home: &Path) -> Result<()> {
+    let path = log_file(home);
+    let meta = match std::fs::metadata(&path) {
+        Ok(m) => m,
+        Err(_) => return Ok(()),
+    };
+    if meta.len() <= MAX_BYTES {
+        return Ok(());
+    }
+    let raw = std::fs::read_to_string(&path)?;
+    let lines: Vec<&str> = raw.lines().collect();
+    // drop the oldest half
+    let keep = &lines[lines.len() / 2..];
+    std::fs::write(&path, format!("{}\n", keep.join("\n")))?;
+    crate::platform::set_mode(&path, 0o600)?;
+    Ok(())
+}
+
+pub fn read(home: &Path) -> Result<Vec<Entry>> {
+    let path = log_file(home);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let raw = std::fs::read_to_string(&path)?;
+    Ok(raw
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<Entry>(l).ok())
+        .collect())
+}
+
+/// Verify the hash-chain. Returns the index of the first broken entry, if any
+/// (a self-hash mismatch = an edited entry; a prev mismatch = a removed entry).
+/// The first entry after a rotation boundary is allowed to reference an absent
+/// predecessor, so we only flag a break when an entry's own hash is wrong or
+/// its `prev` disagrees with the *present* previous line.
+pub fn first_tamper(entries: &[Entry]) -> Option<usize> {
+    for (i, e) in entries.iter().enumerate() {
+        if hash_entry(&e.ts, &e.action, &e.detail, &e.prev) != e.hash {
+            return Some(i); // this entry was edited
+        }
+        if i > 0 && e.prev != entries[i - 1].hash {
+            return Some(i); // an entry between i-1 and i was removed
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn records_and_chains() {
+        let home = TempDir::new().unwrap();
+        record(home.path(), "run", "npm test").unwrap();
+        record(home.path(), "reveal", "openrouter").unwrap();
+        let entries = read(home.path()).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].prev, ""); // first has no predecessor
+        assert_eq!(entries[1].prev, entries[0].hash); // chained
+        assert_eq!(first_tamper(&entries), None); // intact
+    }
+
+    #[test]
+    fn detects_edited_entry() {
+        let home = TempDir::new().unwrap();
+        record(home.path(), "run", "a").unwrap();
+        record(home.path(), "run", "b").unwrap();
+        let mut entries = read(home.path()).unwrap();
+        entries[0].detail = "TAMPERED".into(); // edit content, keep old hash
+        assert_eq!(first_tamper(&entries), Some(0));
+    }
+
+    #[test]
+    fn detects_removed_entry() {
+        let home = TempDir::new().unwrap();
+        record(home.path(), "run", "a").unwrap();
+        record(home.path(), "run", "b").unwrap();
+        record(home.path(), "run", "c").unwrap();
+        let mut entries = read(home.path()).unwrap();
+        entries.remove(1); // drop the middle entry
+                           // now entries[1].prev points at entries[0]'s... no, at the removed one
+        assert_eq!(first_tamper(&entries), Some(1));
+    }
+}

--- a/src/biometric.rs
+++ b/src/biometric.rs
@@ -1,0 +1,54 @@
+//! Cross-platform biometric / password gate (Touch ID on macOS, Windows Hello
+//! on Windows) via `robius-authentication`.
+//!
+//! NOTE: this triggers a native system prompt that cannot be exercised in the
+//! dev/CI environment — it is compile-verified per platform, but the actual
+//! prompt must be tested on real hardware.
+
+use anyhow::Result;
+
+/// Require the user to authenticate before continuing. Ok(()) on success; Err
+/// on denial, timeout, or an unsupported platform (callers fail closed).
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+pub fn require(reason: &str) -> Result<()> {
+    use robius_authentication::{
+        AndroidText, BiometricStrength, Context, PolicyBuilder, Text, WindowsText,
+    };
+
+    let policy = PolicyBuilder::new()
+        .biometrics(Some(BiometricStrength::Strong))
+        .password(true)
+        .build()
+        .ok_or_else(|| anyhow::anyhow!("no authentication method is available"))?;
+
+    let text = Text {
+        android: AndroidText {
+            title: "envault",
+            subtitle: None,
+            description: Some(reason),
+        },
+        apple: reason,
+        windows: WindowsText::new("envault", reason)
+            .ok_or_else(|| anyhow::anyhow!("invalid prompt text"))?,
+    };
+
+    let ctx = Context::new(());
+    let (tx, rx) = std::sync::mpsc::channel();
+    ctx.authenticate(text, &policy, move |res| {
+        let _ = tx.send(res.is_ok());
+    })
+    .map_err(|e| anyhow::anyhow!("authentication error: {e:?}"))?;
+
+    match rx.recv_timeout(std::time::Duration::from_secs(120)) {
+        Ok(true) => Ok(()),
+        Ok(false) => anyhow::bail!("authentication denied"),
+        Err(_) => anyhow::bail!("authentication timed out"),
+    }
+}
+
+/// On platforms without a supported prompt (Linux here), fail closed: if a gate
+/// was requested we cannot verify the user, so deny.
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub fn require(_reason: &str) -> Result<()> {
+    anyhow::bail!("biometric/password gating is not supported on this platform")
+}

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -1,0 +1,164 @@
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use tungstenite::Message;
+
+#[derive(Debug, Deserialize)]
+pub struct Target {
+    #[serde(rename = "type", default)]
+    pub kind: String,
+    #[serde(default)]
+    pub url: String,
+    #[serde(rename = "webSocketDebuggerUrl", default)]
+    pub ws_url: Option<String>,
+}
+
+pub fn list_targets(base: &str) -> Result<Vec<Target>> {
+    let listing = format!("{}/json/list", base.trim_end_matches('/'));
+    let targets: Vec<Target> = ureq::get(&listing)
+        .call()
+        .with_context(|| format!("querying {listing}"))?
+        .into_json()
+        .context("parsing CDP target list")?;
+    Ok(targets)
+}
+
+pub fn pick_page_target(targets: &[Target]) -> Option<&Target> {
+    const INTERNAL: [&str; 3] = ["devtools://", "chrome://", "chrome-extension://"];
+    targets.iter().find(|t| {
+        t.kind == "page"
+            && t.ws_url.is_some()
+            && !INTERNAL.iter().any(|prefix| t.url.starts_with(prefix))
+    })
+}
+
+fn host_of(u: &str) -> Option<String> {
+    url::Url::parse(u)
+        .ok()?
+        .host_str()
+        .map(|h| h.to_lowercase())
+}
+
+pub fn host_matches(secret_url: &str, page_url: &str) -> bool {
+    match (host_of(secret_url), host_of(page_url)) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
+
+pub fn fill_via_cdp(ws_url: &str, selector: Option<&str>, text: &str) -> Result<String> {
+    let (mut ws, _) =
+        tungstenite::connect(ws_url).context("connecting to the browser's CDP websocket")?;
+    let mut next_id: u64 = 1;
+    if let Some(sel) = selector {
+        let expr = format!(
+            "(() => {{ const el = document.querySelector({sel_json}); \
+             if (!el) return 'MISSING'; el.focus(); return 'OK'; }})()",
+            sel_json = serde_json::to_string(sel)?
+        );
+        let reply = cdp_call(
+            &mut ws,
+            &mut next_id,
+            "Runtime.evaluate",
+            serde_json::json!({"expression": expr, "returnByValue": true}),
+        )?;
+        let verdict = reply
+            .pointer("/result/result/value")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if verdict != "OK" {
+            bail!("selector {sel:?} matched no element on the page");
+        }
+    }
+    cdp_call(
+        &mut ws,
+        &mut next_id,
+        "Input.insertText",
+        serde_json::json!({"text": text}),
+    )?;
+    Ok(match selector {
+        Some(s) => format!("into {s}"),
+        None => "into the focused element".to_string(),
+    })
+}
+
+fn cdp_call(
+    ws: &mut tungstenite::WebSocket<tungstenite::stream::MaybeTlsStream<std::net::TcpStream>>,
+    next_id: &mut u64,
+    method: &str,
+    params: serde_json::Value,
+) -> Result<serde_json::Value> {
+    let id = *next_id;
+    *next_id += 1;
+    let msg = serde_json::json!({"id": id, "method": method, "params": params});
+    ws.send(Message::Text(msg.to_string()))
+        .with_context(|| format!("sending {method}"))?;
+    loop {
+        match ws
+            .read()
+            .with_context(|| format!("awaiting {method} reply"))?
+        {
+            Message::Text(t) => {
+                let v: serde_json::Value = serde_json::from_str(&t)?;
+                if v.get("id").and_then(|i| i.as_u64()) == Some(id) {
+                    if let Some(err) = v.get("error") {
+                        bail!("CDP {method} failed: {err}");
+                    }
+                    return Ok(v);
+                }
+            }
+            _ => continue,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(kind: &str, url: &str, ws: Option<&str>) -> Target {
+        Target {
+            kind: kind.into(),
+            url: url.into(),
+            ws_url: ws.map(Into::into),
+        }
+    }
+
+    #[test]
+    fn picks_first_real_page() {
+        let targets = vec![
+            t("background_page", "chrome-extension://x", Some("ws://a")),
+            t("page", "devtools://devtools/inspector.html", Some("ws://b")),
+            t(
+                "page",
+                "chrome://omnibox-popup.top-chrome/",
+                Some("ws://omni"),
+            ),
+            t("page", "chrome-extension://abc/bg.html", Some("ws://ext")),
+            t("page", "https://example.com/login", None),
+            t("page", "https://example.com/login", Some("ws://c")),
+        ];
+        assert_eq!(
+            pick_page_target(&targets).unwrap().ws_url.as_deref(),
+            Some("ws://c")
+        );
+        assert!(pick_page_target(&[]).is_none());
+    }
+
+    #[test]
+    fn host_matching_is_host_only_and_case_insensitive() {
+        assert!(host_matches(
+            "https://openrouter.ai",
+            "https://OPENROUTER.AI/login?x=1"
+        ));
+        assert!(host_matches(
+            "https://example.com/settings",
+            "http://example.com/other"
+        ));
+        assert!(!host_matches(
+            "https://example.com",
+            "https://evil-example.com"
+        ));
+        assert!(!host_matches("https://example.com", "not a url"));
+        assert!(!host_matches("", "https://example.com"));
+    }
+}

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,0 +1,53 @@
+use anyhow::{bail, Context, Result};
+use std::io::Read;
+
+use crate::crypto;
+use crate::paths;
+use crate::store::{is_valid_alias, now_rfc3339, SecretEntry, Vault};
+
+pub fn cmd_add(
+    alias: String,
+    label: Option<String>,
+    url: Option<String>,
+    notes: Option<String>,
+    stdin: bool,
+) -> Result<()> {
+    if !is_valid_alias(&alias) {
+        bail!("alias '{alias}' is invalid — use kebab-case: lowercase letters, digits, '-'");
+    }
+    let home = paths::envault_home();
+    let mut vault = Vault::load(&home)?;
+    if vault.get(&alias).is_some() {
+        bail!("alias '{alias}' already exists");
+    }
+
+    let value = if stdin {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .context("reading value from stdin")?;
+        buf.trim_end_matches(['\n', '\r']).to_string()
+    } else {
+        rpassword::prompt_password(format!("Value for '{alias}' (input hidden): "))
+            .context("reading value (use --stdin when piping)")?
+    };
+    if value.is_empty() {
+        bail!("empty value");
+    }
+
+    let recipient = crypto::load_recipient(&home)?;
+    let cipher = crypto::encrypt_value(&recipient, &value)?;
+    let now = now_rfc3339();
+    vault.insert(SecretEntry {
+        label: label.unwrap_or_else(|| alias.clone()),
+        alias: alias.clone(),
+        cipher,
+        url,
+        created_at: now.clone(),
+        updated_at: now,
+        notes: notes.unwrap_or_default(),
+    })?;
+    vault.save(&home)?;
+    println!("Added '{alias}' (encrypted; value not shown)");
+    Ok(())
+}

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+
+use crate::audit;
+use crate::biometric;
+use crate::paths;
+
+/// Human-only: view the audit log. Always gated behind a system prompt so an
+/// agent can't silently read who accessed what.
+pub fn cmd_audit(json: bool) -> Result<()> {
+    let home = paths::envault_home();
+    biometric::require("View the envault audit log")?;
+
+    let entries = audit::read(&home)?;
+    if entries.is_empty() {
+        println!("audit log is empty (enable it with `envault config set audit-log on`)");
+        return Ok(());
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&entries)?);
+    } else {
+        println!("{:<26} {:<8} DETAIL", "WHEN", "ACTION");
+        for e in &entries {
+            println!("{:<26} {:<8} {}", e.ts, e.action, e.detail);
+        }
+    }
+    match audit::first_tamper(&entries) {
+        None => println!("\n✔ chain intact ({} entries)", entries.len()),
+        Some(i) => {
+            println!("\n✖ TAMPERING DETECTED at entry {i} — the log was edited or truncated")
+        }
+    }
+    Ok(())
+}

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,0 +1,44 @@
+use anyhow::{bail, Result};
+
+use crate::biometric;
+use crate::paths;
+use crate::settings::Settings;
+
+/// `envault config` — show settings. Reading is unguarded (no secrets here).
+pub fn cmd_config_show() -> Result<()> {
+    let s = Settings::load(&paths::envault_home());
+    println!("audit-log : {}", on_off(s.audit_log));
+    println!("touch-id  : {}", on_off(s.touch_id));
+    Ok(())
+}
+
+/// `envault config set <key> <on|off>` — changing a setting is gated, so an
+/// agent can't silently disable the audit log or the Touch ID requirement.
+pub fn cmd_config_set(key: String, value: String) -> Result<()> {
+    let home = paths::envault_home();
+    let on = match value.to_lowercase().as_str() {
+        "on" | "true" | "yes" | "1" => true,
+        "off" | "false" | "no" | "0" => false,
+        other => bail!("value must be on/off, got '{other}'"),
+    };
+
+    biometric::require(&format!("Change envault setting '{key}'"))?;
+
+    let mut s = Settings::load(&home);
+    match key.as_str() {
+        "audit-log" | "audit_log" | "audit" => s.audit_log = on,
+        "touch-id" | "touch_id" | "touchid" => s.touch_id = on,
+        other => bail!("unknown setting '{other}' (try audit-log or touch-id)"),
+    }
+    s.save(&home)?;
+    println!("set {key} = {}", on_off(on));
+    Ok(())
+}
+
+fn on_off(b: bool) -> &'static str {
+    if b {
+        "on"
+    } else {
+        "off"
+    }
+}

--- a/src/commands/fill.rs
+++ b/src/commands/fill.rs
@@ -1,0 +1,41 @@
+use anyhow::{bail, Context, Result};
+
+use crate::cdp;
+use crate::crypto;
+use crate::paths;
+use crate::store::Vault;
+
+pub fn cmd_fill(alias: String, selector: Option<String>, cdp_base: String) -> Result<()> {
+    let home = paths::envault_home();
+    let vault = Vault::load(&home)?;
+    let entry = vault
+        .get(&alias)
+        .with_context(|| format!("alias '{alias}' is not in the vault (see `envault ls`)"))?
+        .clone();
+
+    let targets = cdp::list_targets(&cdp_base).with_context(|| {
+        format!(
+            "no browser CDP endpoint at {cdp_base} — launch the browser with \
+             --remote-debugging-port=9222 (or pass --cdp)"
+        )
+    })?;
+    let target = cdp::pick_page_target(&targets)
+        .context("no page tab found in the browser (open the login page first)")?;
+
+    if let Some(secret_url) = &entry.url {
+        if !cdp::host_matches(secret_url, &target.url) {
+            bail!(
+                "refusing to fill: '{alias}' is registered for {secret_url}, \
+                 but the active page is {}",
+                target.url
+            );
+        }
+    }
+
+    let identity = crate::access::unlock(&home, "fill", &alias)?;
+    let value = crypto::decrypt_value(&identity, &entry.cipher)?;
+    let ws_url = target.ws_url.clone().expect("picked target has ws url");
+    let place = cdp::fill_via_cdp(&ws_url, selector.as_deref(), &value)?;
+    println!("Filled '{alias}' {place} on {}", target.url);
+    Ok(())
+}

--- a/src/commands/guard.rs
+++ b/src/commands/guard.rs
@@ -1,0 +1,201 @@
+use anyhow::Result;
+use std::io::Read;
+
+use crate::paths;
+
+fn collect_strings<'a>(v: &'a serde_json::Value, out: &mut Vec<&'a str>) {
+    match v {
+        serde_json::Value::String(s) => out.push(s),
+        serde_json::Value::Array(a) => a.iter().for_each(|v| collect_strings(v, out)),
+        serde_json::Value::Object(o) => o.values().for_each(|v| collect_strings(v, out)),
+        _ => {}
+    }
+}
+
+pub fn guard_decision(
+    tool_name: &str,
+    tool_input: &serde_json::Value,
+    home: &str,
+) -> Option<String> {
+    let mut strings = Vec::new();
+    collect_strings(tool_input, &mut strings);
+
+    let vault_markers = ["~/.envault", "$HOME/.envault"];
+    for s in &strings {
+        if s.contains(home) || vault_markers.iter().any(|m| s.contains(m)) {
+            return Some(
+                "envault guard: the vault directory is off-limits to agents \
+                 (it holds only ciphers, but defense in depth). \
+                 Use `envault ls --json` to list secret names instead."
+                    .to_string(),
+            );
+        }
+    }
+
+    if tool_name == "Bash" {
+        if let Some(cmd) = tool_input.get("command").and_then(|c| c.as_str()) {
+            for seg in cmd.split([';', '&', '|', '\n']) {
+                let seg = seg.trim();
+                if seg == "envault" {
+                    return Some(
+                        "envault guard: the envault TUI dashboard is human-only. \
+                         Ask the user to run `envault` in their own terminal instead."
+                            .to_string(),
+                    );
+                }
+                if seg == "envault rotate" || seg.starts_with("envault rotate ") {
+                    return Some(
+                        "envault guard: key rotation is human-only (it replaces the \
+                         vault keypair and revokes Keychain grants). Ask the user to \
+                         run `envault rotate` in their own terminal."
+                            .to_string(),
+                    );
+                }
+                if seg.starts_with("envault request-window") {
+                    return Some(
+                        "envault guard: the request window is the human's side of a \
+                         secret handoff. Use `envault request <name> --reason ...` \
+                         instead — it opens the window for the user."
+                            .to_string(),
+                    );
+                }
+                if seg == "envault audit" || seg.starts_with("envault audit ") {
+                    return Some(
+                        "envault guard: the audit log is human-only. Ask the user to \
+                         run `envault audit` in their own terminal."
+                            .to_string(),
+                    );
+                }
+                if seg.starts_with("envault config set") {
+                    return Some(
+                        "envault guard: changing envault settings is human-only. Ask \
+                         the user to run `envault config set …` themselves."
+                            .to_string(),
+                    );
+                }
+            }
+        }
+    }
+    None
+}
+
+pub fn cmd_guard_check() -> Result<i32> {
+    let mut raw = String::new();
+    std::io::stdin().read_to_string(&mut raw)?;
+    let parsed: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("envault guard: unparseable hook input ({e}); allowing");
+            return Ok(0);
+        }
+    };
+    let tool_name = parsed
+        .get("tool_name")
+        .and_then(|t| t.as_str())
+        .unwrap_or("");
+    let empty = serde_json::Value::Object(Default::default());
+    let tool_input = parsed.get("tool_input").unwrap_or(&empty);
+    let home = paths::envault_home();
+    match guard_decision(tool_name, tool_input, &home.to_string_lossy()) {
+        Some(reason) => {
+            eprintln!("{reason}");
+            Ok(2)
+        }
+        None => Ok(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const HOME: &str = "/Users/tester/.envault";
+
+    #[test]
+    fn blocks_reads_of_vault_dir() {
+        for tool in ["Read", "Edit", "Write", "Glob", "Grep"] {
+            let input = json!({"file_path": "/Users/tester/.envault/vault.json"});
+            assert!(
+                guard_decision(tool, &input, HOME).is_some(),
+                "{tool} should block"
+            );
+        }
+        let tilde = json!({"file_path": "~/.envault/vault.json"});
+        assert!(guard_decision("Read", &tilde, HOME).is_some());
+    }
+
+    #[test]
+    fn blocks_bash_touching_vault_dir_or_bare_tui() {
+        let cat = json!({"command": "cat ~/.envault/vault.json"});
+        assert!(guard_decision("Bash", &cat, HOME).is_some());
+        let bare = json!({"command": "envault"});
+        assert!(guard_decision("Bash", &bare, HOME).is_some());
+        let chained = json!({"command": "cd /tmp && envault"});
+        assert!(guard_decision("Bash", &chained, HOME).is_some());
+    }
+
+    #[test]
+    fn blocks_rotate_as_human_only() {
+        for cmd in [
+            "envault rotate",
+            "cd /tmp && envault rotate",
+            "envault rotate --anything",
+        ] {
+            let input = json!({"command": cmd});
+            let verdict = guard_decision("Bash", &input, HOME);
+            assert!(verdict.is_some(), "{cmd} should block");
+            assert!(verdict.unwrap().contains("human-only"), "{cmd}");
+        }
+    }
+
+    #[test]
+    fn blocks_audit_and_config_set_but_allows_config_show() {
+        assert!(guard_decision("Bash", &json!({"command": "envault audit"}), HOME).is_some());
+        assert!(guard_decision(
+            "Bash",
+            &json!({"command": "envault config set audit-log off"}),
+            HOME
+        )
+        .is_some());
+        // reading settings is harmless — allowed
+        assert!(guard_decision("Bash", &json!({"command": "envault config"}), HOME).is_none());
+    }
+
+    #[test]
+    fn blocks_request_window_but_allows_request() {
+        // the human-facing window is off-limits to agents…
+        let win = json!({"command": "envault request-window /tmp/x"});
+        assert!(guard_decision("Bash", &win, HOME).is_some());
+        // …but the request channel itself is the sanctioned agent path
+        let req = json!({"command": "envault request openrouter --reason x"});
+        assert!(guard_decision("Bash", &req, HOME).is_none());
+    }
+
+    #[test]
+    fn allows_normal_envault_usage_and_other_tools() {
+        for cmd in [
+            "envault ls --json",
+            "envault run -- npm test",
+            "envault link OPENROUTER_API_KEY openrouter",
+            "envault import .env",
+            "envault request openrouter --reason \"need it\"",
+            "ls -la",
+        ] {
+            let input = json!({"command": cmd});
+            assert!(
+                guard_decision("Bash", &input, HOME).is_none(),
+                "{cmd} should be allowed"
+            );
+        }
+        let read = json!({"file_path": "/Users/tester/project/src/main.rs"});
+        assert!(guard_decision("Read", &read, HOME).is_none());
+    }
+
+    #[test]
+    fn nested_strings_are_scanned() {
+        let input =
+            json!({"edits": [{"old_string": "x", "new_string": "see ~/.envault/recipient.txt"}]});
+        assert!(guard_decision("Edit", &input, HOME).is_some());
+    }
+}

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,0 +1,67 @@
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+use crate::crypto;
+use crate::manifest::{find_manifest, Manifest, MANIFEST_NAME};
+use crate::paths;
+use crate::store::{is_valid_alias, now_rfc3339, SecretEntry, Vault};
+
+fn to_alias(var: &str) -> String {
+    var.to_lowercase().replace('_', "-")
+}
+
+pub fn cmd_import(file: PathBuf) -> Result<()> {
+    let home = paths::envault_home();
+    let mut vault = Vault::load(&home)?;
+    let recipient = crypto::load_recipient(&home)?;
+
+    let cwd = std::env::current_dir()?;
+    let mut manifest = match find_manifest(&cwd) {
+        Some(path) => Manifest::load(&path)?,
+        None => Manifest {
+            path: cwd.join(MANIFEST_NAME),
+            mappings: Default::default(),
+        },
+    };
+
+    let mut imported = 0usize;
+    let mut skipped = 0usize;
+    for item in
+        dotenvy::from_path_iter(&file).with_context(|| format!("reading {}", file.display()))?
+    {
+        let (var, value) = item.context("parsing dotenv entry")?;
+        let alias = to_alias(&var);
+        if !is_valid_alias(&alias) {
+            eprintln!("skipping {var}: derived alias '{alias}' is invalid");
+            skipped += 1;
+            continue;
+        }
+        if vault.get(&alias).is_some() {
+            eprintln!("skipping {var}: alias '{alias}' already exists");
+            skipped += 1;
+        } else {
+            let now = now_rfc3339();
+            vault.insert(SecretEntry {
+                label: var.clone(),
+                alias: alias.clone(),
+                cipher: crypto::encrypt_value(&recipient, &value)?,
+                url: None,
+                created_at: now.clone(),
+                updated_at: now,
+                notes: format!("imported from {}", file.display()),
+            })?;
+            imported += 1;
+        }
+        manifest.mappings.insert(var, alias);
+    }
+    vault.save(&home)?;
+    manifest.save()?;
+
+    println!("Imported {imported} secret(s) (skipped {skipped}) into the vault");
+    println!("Manifest updated: {}", manifest.path.display());
+    println!(
+        "\nThe plaintext file was NOT deleted. Do it now:\n  rm {}",
+        file.display()
+    );
+    Ok(())
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,26 @@
+use anyhow::{bail, Result};
+use std::fs;
+
+use crate::crypto;
+use crate::paths;
+use crate::store::Vault;
+
+pub fn cmd_init() -> Result<()> {
+    let home = paths::envault_home();
+    if paths::vault_file(&home).exists() {
+        bail!("already initialized at {}", home.display());
+    }
+    fs::create_dir_all(&home)?;
+    crate::platform::set_mode(&home, 0o700)?;
+
+    let identity = crypto::generate_identity();
+    crypto::store_identity(&identity, &home)?;
+    crypto::store_recipient(&identity, &home)?;
+    Vault::default().save(&home)?;
+
+    println!("Initialized envault at {}", home.display());
+    println!("  public key : {}", identity.to_public());
+    println!("  private key: stored in the macOS Keychain (service 'envault')");
+    println!("\nNext: add a secret with `envault add <alias>`");
+    Ok(())
+}

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -1,0 +1,27 @@
+use anyhow::{bail, Result};
+
+use crate::manifest::{find_manifest, Manifest, MANIFEST_NAME};
+use crate::paths;
+use crate::store::Vault;
+
+pub fn cmd_link(env_var: String, alias: String) -> Result<()> {
+    if env_var.is_empty() || env_var.contains('=') || env_var.contains(char::is_whitespace) {
+        bail!("'{env_var}' is not a valid environment variable name");
+    }
+    let vault = Vault::load(&paths::envault_home())?;
+    if vault.get(&alias).is_none() {
+        bail!("alias '{alias}' is not in the vault — create it with `envault add {alias}`");
+    }
+    let cwd = std::env::current_dir()?;
+    let mut manifest = match find_manifest(&cwd) {
+        Some(path) => Manifest::load(&path)?,
+        None => Manifest {
+            path: cwd.join(MANIFEST_NAME),
+            mappings: Default::default(),
+        },
+    };
+    manifest.mappings.insert(env_var.clone(), alias.clone());
+    manifest.save()?;
+    println!("Linked {env_var} -> {alias} in {}", manifest.path.display());
+    Ok(())
+}

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -1,0 +1,36 @@
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::paths;
+use crate::store::Vault;
+
+#[derive(Serialize)]
+struct LsRow<'a> {
+    alias: &'a str,
+    label: &'a str,
+    created_at: &'a str,
+}
+
+pub fn cmd_ls(json: bool) -> Result<()> {
+    let vault = Vault::load(&paths::envault_home())?;
+    let rows: Vec<LsRow> = vault
+        .secrets
+        .iter()
+        .map(|s| LsRow {
+            alias: &s.alias,
+            label: &s.label,
+            created_at: &s.created_at,
+        })
+        .collect();
+    if json {
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+    } else if rows.is_empty() {
+        println!("vault is empty — add one with `envault add <alias>`");
+    } else {
+        println!("{:<24} {:<32} CREATED", "ALIAS", "LABEL");
+        for r in rows {
+            println!("{:<24} {:<32} {}", r.alias, r.label, r.created_at);
+        }
+    }
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,12 @@
+pub mod add;
+pub mod audit;
+pub mod config;
+pub mod fill;
+pub mod guard;
+pub mod import;
+pub mod init;
+pub mod link;
+pub mod ls;
+pub mod request;
+pub mod rotate;
+pub mod run;

--- a/src/commands/request.rs
+++ b/src/commands/request.rs
@@ -1,0 +1,624 @@
+//! `envault request` — the agent-facing channel for asking the human to add a
+//! secret. The agent side spawns a human-only window and waits for the outcome;
+//! the window side runs the request TUI, encrypts a granted value into the
+//! vault, and reports back through a small session file. The agent only ever
+//! learns granted / declined+note / cancelled — never the value.
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+
+use crate::crypto;
+use crate::paths;
+use crate::store::{is_valid_alias, now_rfc3339, SecretEntry, Vault};
+use crate::tui::request::{Outcome, RequestApp, RequestMeta};
+
+#[derive(Serialize, Deserialize)]
+struct RequestFile {
+    name: String,
+    label: String,
+    reason: String,
+    agent: String,
+    caller: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ResultFile {
+    outcome: String,      // granted | declined | cancelled
+    note: Option<String>, // only for declined
+}
+
+/// Agent side: `envault request <name> --reason ... [--label ...] [--agent ...]`.
+pub fn cmd_request(
+    name: String,
+    label: Option<String>,
+    reason: Option<String>,
+    agent: Option<String>,
+) -> Result<i32> {
+    if !is_valid_alias(&name) {
+        bail!("name '{name}' must be kebab-case: lowercase letters, digits, '-'");
+    }
+    let home = paths::envault_home();
+    // If it already exists, the agent is done — no need to bother the human.
+    if Vault::load(&home)
+        .ok()
+        .and_then(|v| v.get(&name).map(|_| ()))
+        .is_some()
+    {
+        println!("'{name}' is already in the vault — use it via `envault run`.");
+        return Ok(0);
+    }
+
+    let meta = RequestFile {
+        name: name.clone(),
+        label: label.unwrap_or_default(),
+        reason: reason.unwrap_or_default(),
+        agent: agent.unwrap_or_else(|| std::env::var("ENVAULT_AGENT").unwrap_or_default()),
+        caller: caller_description(),
+    };
+
+    // Always open a FRESH window — even when run from a terminal — so the
+    // request UI is its own popup and never takes over the current terminal.
+    let session = new_session_dir(&home)?;
+    std::fs::write(session.join("request.json"), serde_json::to_string(&meta)?)?;
+
+    let exe = std::env::current_exe().context("locating the envault binary")?;
+    // Tests (and headless runs) can force the no-window fallback path.
+    let spawn = if std::env::var_os("ENVAULT_NO_WINDOW").is_some() {
+        Err(anyhow::anyhow!("window disabled"))
+    } else {
+        spawn_window(&exe, &session)
+    };
+    if let Err(e) = spawn {
+        let _ = std::fs::remove_dir_all(&session);
+        // Fall back to inline only if no window could open but we still have a
+        // terminal to run in (e.g. SSH). Otherwise, guide the user.
+        if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+            let outcome = run_window(&meta_to_request(&meta))?;
+            return finish(&home, &meta, outcome, None);
+        }
+        eprintln!(
+            "envault: couldn't open a request window ({e}). Ask the user to run:\n  \
+             {} request-window {}",
+            exe.display(),
+            session.display()
+        );
+        return Ok(6);
+    }
+    eprintln!("envault: waiting for the user to respond to the secret request for '{name}'…");
+
+    let result = wait_for_result(&session.join("result.json"), 600)?;
+    // Close the spawned window from here — the parent runs OUTSIDE that window,
+    // so once the window's process has exited it's an idle login shell and
+    // Terminal closes it with no "terminate the running process?" dialog.
+    close_spawned_window(&session);
+    let _ = std::fs::remove_dir_all(&session);
+    match result {
+        Some(r) if r.outcome == "granted" => {
+            println!("granted: '{name}' was added to the vault — use it via `envault run`.");
+            Ok(0)
+        }
+        Some(r) if r.outcome == "declined" => {
+            eprintln!(
+                "declined by user: {}",
+                r.note
+                    .filter(|n| !n.is_empty())
+                    .unwrap_or_else(|| "(no reason given)".into())
+            );
+            Ok(3)
+        }
+        Some(_) => {
+            eprintln!("request cancelled by user.");
+            Ok(4)
+        }
+        None => {
+            eprintln!("request timed out with no response.");
+            Ok(5)
+        }
+    }
+}
+
+/// Window side (hidden): `envault request-window <session-dir>`. Runs in the
+/// spawned terminal, encrypts a granted value, writes the result, self-closes.
+pub fn cmd_request_window(session: PathBuf) -> Result<()> {
+    let raw = std::fs::read_to_string(session.join("request.json"))
+        .with_context(|| format!("reading {}", session.join("request.json").display()))?;
+    let meta: RequestFile = serde_json::from_str(&raw)?;
+
+    // Record our window's tty so the parent (outside this window) can close us.
+    if let Some(tty) = current_tty() {
+        let _ = std::fs::write(session.join("window.tty"), &tty);
+    }
+
+    let outcome = run_window(&meta_to_request(&meta))?;
+    let home = paths::envault_home();
+    finish(&home, &meta, outcome, Some(&session))?;
+    // The parent closes the window; just exit so it becomes an idle shell.
+    Ok(())
+}
+
+fn meta_to_request(m: &RequestFile) -> RequestMeta {
+    RequestMeta {
+        name: m.name.clone(),
+        label: m.label.clone(),
+        reason: m.reason.clone(),
+        agent: if m.agent.is_empty() {
+            "an unidentified agent".into()
+        } else {
+            m.agent.clone()
+        },
+        caller: m.caller.clone(),
+    }
+}
+
+/// Apply the outcome: encrypt+store on grant, and report into `session`
+/// (the spawned-window path) when one is given.
+fn finish(
+    home: &Path,
+    meta: &RequestFile,
+    outcome: Outcome,
+    session: Option<&Path>,
+) -> Result<i32> {
+    let (result, code) = match outcome {
+        Outcome::Granted(value) => {
+            let recipient = crypto::load_recipient(home)?;
+            let cipher = crypto::encrypt_value(&recipient, &value)?;
+            let mut vault = Vault::load(home)?;
+            if vault.get(&meta.name).is_none() {
+                let now = now_rfc3339();
+                vault.insert(SecretEntry {
+                    label: if meta.label.is_empty() {
+                        meta.name.clone()
+                    } else {
+                        meta.label.clone()
+                    },
+                    alias: meta.name.clone(),
+                    cipher,
+                    url: None,
+                    created_at: now.clone(),
+                    updated_at: now,
+                    notes: if meta.reason.is_empty() {
+                        String::new()
+                    } else {
+                        format!("requested by {}: {}", meta.agent, meta.reason)
+                    },
+                })?;
+                vault.save(home)?;
+            }
+            println!("✔ added '{}' to the vault.", meta.name);
+            (
+                ResultFile {
+                    outcome: "granted".into(),
+                    note: None,
+                },
+                0,
+            )
+        }
+        Outcome::Declined(note) => {
+            println!("declined — the agent has been told.");
+            (
+                ResultFile {
+                    outcome: "declined".into(),
+                    note: Some(note),
+                },
+                3,
+            )
+        }
+        Outcome::Cancelled => (
+            ResultFile {
+                outcome: "cancelled".into(),
+                note: None,
+            },
+            4,
+        ),
+    };
+    // Only the spawned-window path has a session to report into.
+    if let Some(dir) = session {
+        std::fs::write(dir.join("result.json"), serde_json::to_string(&result)?).ok();
+    }
+    Ok(code)
+}
+
+// ── plumbing ────────────────────────────────────────────────────────────────
+
+fn new_session_dir(home: &Path) -> Result<PathBuf> {
+    let base = home.join("requests");
+    std::fs::create_dir_all(&base)?;
+    // Unique without randomness: pid + monotonic-ish counter via nanos-free time
+    // is unavailable here, so pid + a scan suffices for a single user.
+    let mut n = 0u32;
+    loop {
+        let dir = base.join(format!("{}-{n}", std::process::id()));
+        if !dir.exists() {
+            std::fs::create_dir(&dir)?;
+            crate::platform::set_mode(&dir, 0o700)?;
+            return Ok(dir);
+        }
+        n += 1;
+    }
+}
+
+/// macOS: open a small centered Terminal.app window running the request TUI.
+#[cfg(target_os = "macos")]
+fn spawn_window(exe: &Path, session: &Path) -> Result<()> {
+    use std::process::Stdio;
+    // Carry the caller's vault selection into the fresh login shell that
+    // `do script` spawns, so the window writes to the same vault we checked.
+    let mut env_prefix = String::new();
+    for key in ["ENVAULT_HOME", "ENVAULT_IDENTITY_FILE"] {
+        if let Ok(val) = std::env::var(key) {
+            env_prefix.push_str(&format!("{key}={} ", shell_quote(&val)));
+        }
+    }
+    let cmd = format!(
+        "{env_prefix}{exe} request-window {session}",
+        session = shell_quote(&session.to_string_lossy()),
+        exe = shell_quote(&exe.to_string_lossy()),
+    );
+    let script = format!(
+        "tell application \"Finder\" to set sb to bounds of window of desktop\n\
+         set sw to item 3 of sb\n\
+         set sh to item 4 of sb\n\
+         set ww to 660\n\
+         set wh to 460\n\
+         set x1 to (sw - ww) / 2 as integer\n\
+         set y1 to (sh - wh) / 2 as integer\n\
+         tell application \"Terminal\"\n\
+         activate\n\
+         do script \"{}\"\n\
+         delay 0.2\n\
+         try\n\
+         set bounds of front window to {{x1, y1, x1 + ww, y1 + wh}}\n\
+         end try\n\
+         end tell",
+        applescript_escape(&cmd),
+    );
+    // Suppress osascript's own output so it never pollutes our stdout.
+    let status = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("launching osascript")?;
+    if !status.success() {
+        bail!("osascript exited with {status}");
+    }
+    Ok(())
+}
+
+/// Windows: open a fresh window running the request TUI — Windows Terminal
+/// (`wt`) if present for a nicer look, else a PowerShell console. Either way
+/// the window closes on its own when the process exits. The child inherits our
+/// environment, so ENVAULT_HOME/ENVAULT_IDENTITY_FILE carry over.
+#[cfg(target_os = "windows")]
+fn spawn_window(exe: &Path, session: &Path) -> Result<()> {
+    use std::process::Stdio;
+    let exe = exe.to_string_lossy().to_string();
+    let session = session.to_string_lossy().to_string();
+
+    // Prefer Windows Terminal, sized to a small popup.
+    let wt = std::process::Command::new("wt")
+        .args([
+            "--size",
+            "84,26",
+            "new-tab",
+            "--title",
+            "envault - secret request",
+        ])
+        .arg(&exe)
+        .arg("request-window")
+        .arg(&session)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+    if wt.is_ok() {
+        return Ok(());
+    }
+
+    // Fallback: a plain PowerShell console window via Start-Process.
+    let ps = format!(
+        "Start-Process -FilePath {} -ArgumentList @('request-window', {})",
+        ps_quote(&exe),
+        ps_quote(&session),
+    );
+    let status = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &ps])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("launching powershell")?;
+    if !status.success() {
+        bail!("could not open a PowerShell window");
+    }
+    Ok(())
+}
+
+/// Linux/BSD: try a few common terminal emulators; each runs our command and
+/// closes when it exits. Returns Err if none are found (caller falls back to
+/// running inline).
+#[cfg(all(unix, not(target_os = "macos")))]
+fn spawn_window(exe: &Path, session: &Path) -> Result<()> {
+    use std::process::Stdio;
+    let inner = format!(
+        "{} request-window {}",
+        shell_quote(&exe.to_string_lossy()),
+        shell_quote(&session.to_string_lossy()),
+    );
+    // (program, args) — most emulators take `-e <cmd...>`.
+    let attempts: [(&str, Vec<String>); 5] = [
+        (
+            "x-terminal-emulator",
+            vec!["-e".into(), "sh".into(), "-c".into(), inner.clone()],
+        ),
+        (
+            "gnome-terminal",
+            vec!["--".into(), "sh".into(), "-c".into(), inner.clone()],
+        ),
+        (
+            "konsole",
+            vec!["-e".into(), "sh".into(), "-c".into(), inner.clone()],
+        ),
+        (
+            "xterm",
+            vec!["-e".into(), "sh".into(), "-c".into(), inner.clone()],
+        ),
+        (
+            "alacritty",
+            vec!["-e".into(), "sh".into(), "-c".into(), inner.clone()],
+        ),
+    ];
+    for (term, args) in attempts {
+        let spawned = std::process::Command::new(term)
+            .args(&args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn();
+        if spawned.is_ok() {
+            return Ok(());
+        }
+    }
+    bail!("no supported terminal emulator found (tried gnome-terminal, konsole, xterm, alacritty)");
+}
+
+fn wait_for_result(result_path: &Path, timeout_secs: u64) -> Result<Option<ResultFile>> {
+    let deadline = timeout_secs * 10; // 100ms ticks
+    for _ in 0..deadline {
+        if result_path.exists() {
+            let raw = std::fs::read_to_string(result_path)?;
+            if let Ok(r) = serde_json::from_str::<ResultFile>(&raw) {
+                return Ok(Some(r));
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    Ok(None)
+}
+
+/// Run the request TUI to completion in the current terminal.
+fn run_window(meta: &RequestMeta) -> Result<Outcome> {
+    use crossterm::event::{self, Event, KeyEventKind};
+    use ratatui::backend::CrosstermBackend;
+    use ratatui::Terminal;
+
+    let mut app = RequestApp::new(meta.clone());
+    crossterm::terminal::enable_raw_mode()?;
+    crossterm::execute!(std::io::stdout(), crossterm::terminal::EnterAlternateScreen)?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(std::io::stdout()))?;
+    let outcome = loop {
+        terminal.draw(|f| crate::tui::request::draw(f, &app))?;
+        if let Event::Key(k) = event::read()? {
+            if k.kind == KeyEventKind::Press {
+                if let Some(o) = app.handle_key(k) {
+                    break o;
+                }
+            }
+        }
+    };
+    crossterm::execute!(std::io::stdout(), crossterm::terminal::LeaveAlternateScreen).ok();
+    crossterm::terminal::disable_raw_mode().ok();
+    Ok(outcome)
+}
+
+/// The controlling terminal device of this process, e.g. `/dev/ttys003`.
+/// `tty` must inherit our real stdin (fd 0) — `Command::output()` nulls stdin
+/// by default, which would make `tty` report "not a tty" and return None.
+/// Only macOS needs it (to close its Terminal window by tty).
+#[cfg(target_os = "macos")]
+fn current_tty() -> Option<String> {
+    let out = std::process::Command::new("tty")
+        .stdin(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.starts_with("/dev/") {
+        Some(s)
+    } else {
+        None
+    }
+}
+
+/// Non-macOS: no tty tracking needed — Windows consoles and Linux terminal
+/// emulators close on their own when the launched process exits.
+#[cfg(not(target_os = "macos"))]
+fn current_tty() -> Option<String> {
+    None
+}
+
+/// macOS: close the spawned Terminal window from the parent (which is outside
+/// it). The window's process has written its result and is exiting; a short
+/// wait lets it become an idle login shell, which Terminal closes with no
+/// confirmation dialog. `saving no` suppresses any save prompt.
+#[cfg(target_os = "macos")]
+fn close_spawned_window(session: &Path) {
+    let Ok(tty) = std::fs::read_to_string(session.join("window.tty")) else {
+        return;
+    };
+    let tty = tty.trim();
+    if tty.is_empty() {
+        return;
+    }
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    let script = format!(
+        "tell application \"Terminal\" to close (every window whose tty is \"{}\") saving no",
+        applescript_escape(tty),
+    );
+    let _ = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+/// Non-macOS: nothing to do — the window closes itself when its process exits.
+#[cfg(not(target_os = "macos"))]
+fn close_spawned_window(_session: &Path) {}
+
+/// A short, human-meaningful description of the process that launched us, for
+/// cross-checking the agent's claimed `--agent` identity. Unix uses `ps`.
+#[cfg(unix)]
+fn caller_description() -> String {
+    let ppid = parent_pid();
+    let comm = ppid
+        .and_then(|p| {
+            std::process::Command::new("ps")
+                .args(["-o", "comm=", "-p", &p.to_string()])
+                .output()
+                .ok()
+        })
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".into());
+    match ppid {
+        Some(p) => format!("{comm} (pid {p})"),
+        None => comm,
+    }
+}
+
+#[cfg(unix)]
+fn parent_pid() -> Option<u32> {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "ppid=", "-p", &std::process::id().to_string()])
+        .output()
+        .ok()?;
+    String::from_utf8_lossy(&out.stdout).trim().parse().ok()
+}
+
+/// Windows: look up our parent process via PowerShell/CIM (best effort).
+#[cfg(windows)]
+fn caller_description() -> String {
+    let pid = std::process::id();
+    let ps = format!(
+        "$pp=(Get-CimInstance Win32_Process -Filter 'ProcessId={pid}').ParentProcessId; \
+         $n=(Get-Process -Id $pp -ErrorAction SilentlyContinue).ProcessName; \
+         if ($n) {{ \"$n (pid $pp)\" }} else {{ \"pid $pp\" }}"
+    );
+    std::process::Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &ps])
+        .output()
+        .ok()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "a local process".into())
+}
+
+#[cfg(unix)]
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+#[cfg(windows)]
+fn ps_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "''"))
+}
+
+#[cfg(target_os = "macos")]
+fn applescript_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::{decrypt_value, generate_identity, store_recipient};
+
+    fn meta(name: &str) -> RequestFile {
+        RequestFile {
+            name: name.into(),
+            label: "My Label".into(),
+            reason: "the demo".into(),
+            agent: "Test Agent".into(),
+            caller: "bash (pid 1)".into(),
+        }
+    }
+
+    #[test]
+    fn grant_encrypts_into_vault_and_reports() {
+        let home = tempfile::TempDir::new().unwrap();
+        let session = tempfile::TempDir::new().unwrap();
+        let id = generate_identity();
+        store_recipient(&id, home.path()).unwrap();
+        Vault::default().save(home.path()).unwrap();
+
+        let code = finish(
+            home.path(),
+            &meta("newkey"),
+            Outcome::Granted("granted-secret-42".into()),
+            Some(session.path()),
+        )
+        .unwrap();
+        assert_eq!(code, 0);
+
+        // stored + decrypts to exactly the granted bytes; reason recorded
+        let vault = Vault::load(home.path()).unwrap();
+        let entry = vault.get("newkey").expect("added");
+        assert_eq!(entry.label, "My Label");
+        assert_eq!(
+            decrypt_value(&id, &entry.cipher).unwrap(),
+            "granted-secret-42"
+        );
+        assert!(entry.notes.contains("Test Agent") && entry.notes.contains("the demo"));
+
+        // plaintext never lands on disk
+        let raw = std::fs::read_to_string(crate::paths::vault_file(home.path())).unwrap();
+        assert!(!raw.contains("granted-secret-42"));
+
+        // the agent-facing result says granted, no value
+        let result = std::fs::read_to_string(session.path().join("result.json")).unwrap();
+        assert!(result.contains("granted"));
+        assert!(!result.contains("granted-secret-42"));
+    }
+
+    #[test]
+    fn command_escaping_is_safe() {
+        // shell_quote keeps a value with spaces/quotes as one safe argument
+        assert_eq!(shell_quote("a b"), "'a b'");
+        assert_eq!(shell_quote("it's"), "'it'\\''s'");
+        // applescript_escape neutralizes quotes and backslashes
+        assert_eq!(applescript_escape("a\"b\\c"), "a\\\"b\\\\c");
+    }
+
+    #[test]
+    fn decline_writes_note_and_adds_nothing() {
+        let home = tempfile::TempDir::new().unwrap();
+        let session = tempfile::TempDir::new().unwrap();
+        let id = generate_identity();
+        store_recipient(&id, home.path()).unwrap();
+        Vault::default().save(home.path()).unwrap();
+
+        let code = finish(
+            home.path(),
+            &meta("newkey"),
+            Outcome::Declined("use deepseek instead".into()),
+            Some(session.path()),
+        )
+        .unwrap();
+        assert_eq!(code, 3);
+        assert!(Vault::load(home.path()).unwrap().get("newkey").is_none());
+        let result = std::fs::read_to_string(session.path().join("result.json")).unwrap();
+        assert!(result.contains("declined") && result.contains("use deepseek instead"));
+    }
+}

--- a/src/commands/rotate.rs
+++ b/src/commands/rotate.rs
@@ -1,0 +1,63 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
+
+use crate::crypto;
+use crate::paths;
+use crate::store::Vault;
+
+pub struct RotateOutcome {
+    pub count: usize,
+    pub recipient: age::x25519::Recipient,
+}
+
+/// Re-encrypt every secret to a brand-new keypair. Shared by the CLI command
+/// and the TUI's `:rotate`.
+pub fn rotate_in_place(home: &Path) -> Result<RotateOutcome> {
+    let mut vault = Vault::load(home)?;
+    let old_identity = crate::access::unlock(home, "rotate", "re-key vault")?;
+
+    // Decrypt everything up front: any failure aborts before any state changes.
+    let mut values: Vec<String> = Vec::with_capacity(vault.secrets.len());
+    for entry in &vault.secrets {
+        values.push(
+            crypto::decrypt_value(&old_identity, &entry.cipher)
+                .with_context(|| format!("decrypting '{}' with the current key", entry.alias))?,
+        );
+    }
+
+    let new_identity = crypto::generate_identity();
+    let new_recipient = new_identity.to_public();
+    for (entry, value) in vault.secrets.iter_mut().zip(&values) {
+        entry.cipher = crypto::encrypt_value(&new_recipient, value)?;
+    }
+
+    // Stage the re-encrypted vault first: if the identity swap below fails,
+    // nothing has changed; the lockout window is just the rename.
+    let staged = home.join("vault.json.new");
+    fs::write(&staged, serde_json::to_string_pretty(&vault)?)?;
+    crate::platform::set_mode(&staged, 0o600)?;
+
+    // Delete-then-create gives the new Keychain item a fresh ACL, so macOS
+    // asks for authorization again: rotation revokes every prior grant.
+    crypto::delete_identity()?;
+    crypto::store_identity(&new_identity, home)?;
+    fs::rename(&staged, paths::vault_file(home)).context("activating the rotated vault")?;
+    crypto::store_recipient(&new_identity, home)?;
+
+    Ok(RotateOutcome {
+        count: values.len(),
+        recipient: new_recipient,
+    })
+}
+
+pub fn cmd_rotate() -> Result<()> {
+    let outcome = rotate_in_place(&paths::envault_home())?;
+    println!("Rotated {} secret(s) to a new keypair", outcome.count);
+    println!("  new public key: {}", outcome.recipient);
+    println!(
+        "\nmacOS will ask for Keychain authorization again on next use — intentional:\n\
+         rotation revokes every previously granted 'Always Allow'."
+    );
+    Ok(())
+}

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,0 +1,155 @@
+use anyhow::{bail, Context, Result};
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use std::io::{IsTerminal, Read, Write};
+use std::path::PathBuf;
+
+use crate::crypto;
+use crate::manifest::find_manifest;
+use crate::masker::Masker;
+use crate::paths;
+use crate::store::Vault;
+
+pub struct RunArgs {
+    pub manifest: Option<PathBuf>,
+    pub env: Vec<String>,
+    pub allow_missing: bool,
+    pub command: Vec<String>,
+}
+
+/// Restores cooked mode even on early return / panic.
+struct RawGuard(bool);
+impl RawGuard {
+    fn enable() -> RawGuard {
+        if std::io::stdin().is_terminal() {
+            crossterm::terminal::enable_raw_mode().ok();
+            RawGuard(true)
+        } else {
+            RawGuard(false)
+        }
+    }
+}
+impl Drop for RawGuard {
+    fn drop(&mut self) {
+        if self.0 {
+            crossterm::terminal::disable_raw_mode().ok();
+        }
+    }
+}
+
+pub fn cmd_run(args: RunArgs) -> Result<i32> {
+    if args.command.is_empty() {
+        bail!("no command given — usage: envault run -- <cmd> [args...]");
+    }
+
+    // 1. Collect ENV_VAR -> alias mappings: manifest (optional) + --env flags.
+    let cwd = std::env::current_dir()?;
+    let mut mappings: Vec<(String, String)> = Vec::new();
+    let manifest_path = args.manifest.clone().or_else(|| find_manifest(&cwd));
+    if let Some(path) = &manifest_path {
+        let m = crate::manifest::Manifest::load(path)?;
+        mappings.extend(m.mappings);
+    }
+    for spec in &args.env {
+        let (var, alias) = spec
+            .split_once('=')
+            .with_context(|| format!("--env expects VAR=alias, got '{spec}'"))?;
+        mappings.push((var.to_string(), alias.to_string()));
+    }
+    if mappings.is_empty() && manifest_path.is_none() && !args.allow_missing {
+        bail!(
+            "no envault.toml found (searched {} upward) and no --env mappings; \
+             use --allow-missing to run without injection",
+            cwd.display()
+        );
+    }
+
+    // 2. Resolve aliases against the vault; report ALL missing at once.
+    let home = paths::envault_home();
+    let vault = if mappings.is_empty() {
+        Vault::default()
+    } else {
+        Vault::load(&home)?
+    };
+    let missing: Vec<&(String, String)> = mappings
+        .iter()
+        .filter(|(_, a)| vault.get(a).is_none())
+        .collect();
+    if !missing.is_empty() && !args.allow_missing {
+        let list = missing
+            .iter()
+            .map(|(v, a)| format!("  {v} -> {a}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        bail!("aliases missing from the vault:\n{list}\nadd them with `envault add <alias>`");
+    }
+
+    // 3. Decrypt (gated + audited via the access choke point).
+    let mut injected: Vec<(String, String, String)> = Vec::new(); // (var, alias, value)
+    if mappings.iter().any(|(_, a)| vault.get(a).is_some()) {
+        let identity = crate::access::unlock(&home, "run", &args.command.join(" "))?;
+        for (var, alias) in &mappings {
+            if let Some(entry) = vault.get(alias) {
+                let value = crypto::decrypt_value(&identity, &entry.cipher)?;
+                injected.push((var.clone(), alias.clone(), value));
+            }
+        }
+    }
+    let masker_input: Vec<(String, String)> = injected
+        .iter()
+        .map(|(_, a, v)| (a.clone(), v.clone()))
+        .collect();
+
+    // 4. Spawn in a PTY.
+    let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .context("opening pty")?;
+    let mut cmd = CommandBuilder::new(&args.command[0]);
+    cmd.args(&args.command[1..]);
+    cmd.cwd(&cwd);
+    for (k, v) in std::env::vars() {
+        cmd.env(k, v);
+    }
+    for (var, _, value) in &injected {
+        cmd.env(var, value); // injected wins on collision
+    }
+    let mut child = pair.slave.spawn_command(cmd).context("spawning command")?;
+    drop(pair.slave);
+
+    // 5. Pump stdin -> child, and child -> masked stdout.
+    let mut writer = pair.master.take_writer().context("pty writer")?;
+    std::thread::spawn(move || {
+        let mut stdin = std::io::stdin();
+        let mut buf = [0u8; 4096];
+        while let Ok(n) = stdin.read(&mut buf) {
+            if n == 0 || writer.write_all(&buf[..n]).is_err() {
+                break;
+            }
+        }
+    });
+
+    let _raw = RawGuard::enable();
+    let mut reader = pair.master.try_clone_reader().context("pty reader")?;
+    let mut masker = Masker::new(&masker_input);
+    let mut stdout = std::io::stdout();
+    let mut buf = [0u8; 8192];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) | Err(_) => break, // EOF or pty closed
+            Ok(n) => {
+                stdout.write_all(&masker.feed(&buf[..n]))?;
+                stdout.flush()?;
+            }
+        }
+    }
+    stdout.write_all(&masker.flush())?;
+    stdout.flush()?;
+
+    let status = child.wait().context("waiting for command")?;
+    Ok(status.exit_code() as i32)
+}

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,162 @@
+use anyhow::{Context, Result};
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+
+pub fn generate_identity() -> age::x25519::Identity {
+    age::x25519::Identity::generate()
+}
+
+pub fn encrypt_value(recipient: &age::x25519::Recipient, plaintext: &str) -> Result<String> {
+    let bytes = age::encrypt(recipient, plaintext.as_bytes()).context("age encryption failed")?;
+    Ok(B64.encode(bytes))
+}
+
+pub fn decrypt_value(identity: &age::x25519::Identity, cipher_b64: &str) -> Result<String> {
+    let bytes = B64
+        .decode(cipher_b64.trim())
+        .context("cipher is not valid base64")?;
+    let plain = age::decrypt(identity, &bytes)
+        .context("decryption failed (wrong key or corrupt cipher)")?;
+    String::from_utf8(plain).context("decrypted value is not UTF-8")
+}
+
+use age::secrecy::ExposeSecret;
+use std::fs;
+use std::path::Path;
+use std::str::FromStr;
+
+const KEYCHAIN_SERVICE: &str = "envault";
+const KEYCHAIN_ACCOUNT: &str = "age-identity";
+
+fn identity_file_override() -> Option<std::path::PathBuf> {
+    std::env::var("ENVAULT_IDENTITY_FILE").ok().map(Into::into)
+}
+
+pub fn store_identity(identity: &age::x25519::Identity, _home: &Path) -> Result<()> {
+    let key = identity.to_string(); // SecretString
+    if let Some(path) = identity_file_override() {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, format!("{}\n", key.expose_secret()))?;
+        crate::platform::set_mode(&path, 0o600)?;
+        return Ok(());
+    }
+    let entry = keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)
+        .context("opening Keychain entry")?;
+    entry
+        .set_password(key.expose_secret())
+        .context("storing identity in the macOS Keychain")
+}
+
+pub fn load_identity() -> Result<age::x25519::Identity> {
+    let raw = if let Some(path) = identity_file_override() {
+        fs::read_to_string(&path)
+            .with_context(|| format!("reading identity file {}", path.display()))?
+    } else {
+        let entry = keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)
+            .context("opening Keychain entry")?;
+        entry.get_password().context(
+            "no envault identity in the Keychain — run `envault init` (or grant Keychain access)",
+        )?
+    };
+    age::x25519::Identity::from_str(raw.trim())
+        .map_err(|e| anyhow::anyhow!("invalid age identity: {e}"))
+}
+
+pub fn delete_identity() -> Result<()> {
+    if let Some(path) = identity_file_override() {
+        if path.exists() {
+            fs::remove_file(&path)?;
+        }
+        return Ok(());
+    }
+    let entry = keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)
+        .context("opening Keychain entry")?;
+    match entry.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(e).context("deleting the old identity from the Keychain"),
+    }
+}
+
+pub fn store_recipient(identity: &age::x25519::Identity, home: &Path) -> Result<()> {
+    fs::create_dir_all(home)?;
+    fs::write(
+        crate::paths::recipient_file(home),
+        format!("{}\n", identity.to_public()),
+    )?;
+    Ok(())
+}
+
+pub fn load_recipient(home: &Path) -> Result<age::x25519::Recipient> {
+    let path = crate::paths::recipient_file(home);
+    if !path.exists() {
+        anyhow::bail!(
+            "no recipient at {} — run `envault init` first",
+            path.display()
+        );
+    }
+    let raw = fs::read_to_string(&path)?;
+    age::x25519::Recipient::from_str(raw.trim())
+        .map_err(|e| anyhow::anyhow!("invalid recipient: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let id = generate_identity();
+        let cipher = encrypt_value(&id.to_public(), "sk-or-v1-secret").unwrap();
+        assert_ne!(cipher, "sk-or-v1-secret");
+        assert!(!cipher.contains("secret"));
+        let plain = decrypt_value(&id, &cipher).unwrap();
+        assert_eq!(plain, "sk-or-v1-secret");
+    }
+
+    #[test]
+    fn wrong_identity_fails() {
+        let id = generate_identity();
+        let other = generate_identity();
+        let cipher = encrypt_value(&id.to_public(), "value-123").unwrap();
+        assert!(decrypt_value(&other, &cipher).is_err());
+    }
+
+    #[test]
+    fn garbage_cipher_fails() {
+        let id = generate_identity();
+        assert!(decrypt_value(&id, "not base64 !!!").is_err());
+        assert!(decrypt_value(&id, "aGVsbG8=").is_err()); // valid b64, not age data
+    }
+
+    #[test]
+    fn identity_file_roundtrip() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let id_path = dir.path().join("identity.txt");
+        // Only unit test that mutates process env; keep it that way to stay parallel-safe.
+        std::env::set_var("ENVAULT_IDENTITY_FILE", &id_path);
+        let id = generate_identity();
+        store_identity(&id, dir.path()).unwrap();
+        store_recipient(&id, dir.path()).unwrap();
+        let loaded = load_identity().unwrap();
+        std::env::remove_var("ENVAULT_IDENTITY_FILE");
+
+        let cipher = encrypt_value(&load_recipient(dir.path()).unwrap(), "roundtrip").unwrap();
+        assert_eq!(decrypt_value(&loaded, &cipher).unwrap(), "roundtrip");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&id_path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+    }
+
+    #[test]
+    fn missing_recipient_mentions_init() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let err = load_recipient(dir.path()).unwrap_err().to_string();
+        assert!(err.contains("envault init"), "got: {err}");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,177 @@
+use clap::{Parser, Subcommand};
+
+mod access;
+mod audit;
+mod biometric;
+mod cdp;
+mod commands;
+mod crypto;
+mod manifest;
+mod masker;
+mod paths;
+mod platform;
+mod settings;
+mod store;
+mod tui;
+
+#[derive(Parser)]
+#[command(
+    name = "envault",
+    version,
+    about = "Local secrets vault: agents see aliases and ciphers, never plaintext"
+)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Option<Cmd>,
+}
+
+#[derive(Subcommand)]
+enum ConfigAction {
+    /// Change a setting: `envault config set audit-log on`
+    Set { key: String, value: String },
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Create the vault and generate the keypair
+    Init,
+    /// Add a secret (value via hidden prompt, or --stdin)
+    Add {
+        alias: String,
+        #[arg(long)]
+        label: Option<String>,
+        #[arg(long)]
+        url: Option<String>,
+        #[arg(long)]
+        notes: Option<String>,
+        /// Read the value from stdin (for piping); otherwise prompts on the TTY
+        #[arg(long)]
+        stdin: bool,
+    },
+    /// List secret names (never values)
+    Ls {
+        #[arg(long)]
+        json: bool,
+    },
+    /// View the audit log of secret accesses (human-only; system-prompt gated)
+    Audit {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show or change settings (audit-log, touch-id)
+    Config {
+        #[command(subcommand)]
+        action: Option<ConfigAction>,
+    },
+    /// Map a project env var to a vault alias in envault.toml
+    Link { env_var: String, alias: String },
+    /// Type a secret into the browser page over CDP (value never shown)
+    Fill {
+        alias: String,
+        /// CSS selector to focus first; omit to use the focused element
+        #[arg(long)]
+        selector: Option<String>,
+        /// DevTools endpoint of the browser
+        #[arg(long, default_value = "http://127.0.0.1:9222")]
+        cdp: String,
+    },
+    /// Internal: PreToolUse hook helper (reads hook JSON on stdin)
+    #[command(hide = true)]
+    GuardCheck,
+    /// Encrypt every entry of a dotenv file into the vault and link it
+    Import { file: std::path::PathBuf },
+    /// Ask the user (in a pop-up window) to add a secret you don't have yet
+    Request {
+        /// The name the secret will be stored under (agent-chosen)
+        name: String,
+        #[arg(long)]
+        label: Option<String>,
+        /// Why you need it — shown to the user so they can decide
+        #[arg(long)]
+        reason: Option<String>,
+        /// Identify yourself, e.g. --agent "Claude Code"
+        #[arg(long)]
+        agent: Option<String>,
+    },
+    /// Internal: the human-facing request window (spawned in a new terminal)
+    #[command(hide = true)]
+    RequestWindow { session: std::path::PathBuf },
+    /// Re-encrypt the vault to a brand-new keypair (revokes Keychain grants)
+    Rotate,
+    /// Run a command with secrets injected and masked out of its output
+    Run {
+        #[arg(long)]
+        manifest: Option<std::path::PathBuf>,
+        /// Extra VAR=alias mappings (repeatable)
+        #[arg(long)]
+        env: Vec<String>,
+        #[arg(long)]
+        allow_missing: bool,
+        /// Everything after `--` is the command to run
+        #[arg(last = true)]
+        command: Vec<String>,
+    },
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let result = match cli.cmd {
+        None => tui::run_tui(),
+        Some(Cmd::Init) => commands::init::cmd_init(),
+        Some(Cmd::Add {
+            alias,
+            label,
+            url,
+            notes,
+            stdin,
+        }) => commands::add::cmd_add(alias, label, url, notes, stdin),
+        Some(Cmd::Ls { json }) => commands::ls::cmd_ls(json),
+        Some(Cmd::Audit { json }) => commands::audit::cmd_audit(json),
+        Some(Cmd::Config { action }) => match action {
+            None => commands::config::cmd_config_show(),
+            Some(ConfigAction::Set { key, value }) => commands::config::cmd_config_set(key, value),
+        },
+        Some(Cmd::Link { env_var, alias }) => commands::link::cmd_link(env_var, alias),
+        Some(Cmd::Fill {
+            alias,
+            selector,
+            cdp,
+        }) => commands::fill::cmd_fill(alias, selector, cdp),
+        Some(Cmd::GuardCheck) => match commands::guard::cmd_guard_check() {
+            Ok(code) => std::process::exit(code),
+            Err(e) => Err(e),
+        },
+        Some(Cmd::Import { file }) => commands::import::cmd_import(file),
+        Some(Cmd::Request {
+            name,
+            label,
+            reason,
+            agent,
+        }) => match commands::request::cmd_request(name, label, reason, agent) {
+            Ok(code) => std::process::exit(code),
+            Err(e) => Err(e),
+        },
+        Some(Cmd::RequestWindow { session }) => commands::request::cmd_request_window(session),
+        Some(Cmd::Rotate) => commands::rotate::cmd_rotate(),
+        Some(Cmd::Run {
+            manifest,
+            env,
+            allow_missing,
+            command,
+        }) => {
+            match commands::run::cmd_run(commands::run::RunArgs {
+                manifest,
+                env,
+                allow_missing,
+                command,
+            }) {
+                Ok(code) => std::process::exit(code),
+                Err(e) => Err(e),
+            }
+        }
+    };
+    if let Err(e) = result {
+        eprintln!("error: {e:#}");
+        std::process::exit(1);
+    }
+}

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,102 @@
+use anyhow::{bail, Context, Result};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+pub const MANIFEST_NAME: &str = "envault.toml";
+
+pub fn find_manifest(start: &Path) -> Option<PathBuf> {
+    let mut dir = Some(start);
+    while let Some(d) = dir {
+        let candidate = d.join(MANIFEST_NAME);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+#[derive(Debug)]
+pub struct Manifest {
+    pub path: PathBuf,
+    pub mappings: BTreeMap<String, String>,
+}
+
+impl Manifest {
+    pub fn load(path: &Path) -> Result<Manifest> {
+        let raw =
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+        let value: toml::Value = raw
+            .parse()
+            .with_context(|| format!("parsing {}", path.display()))?;
+        let table = value
+            .as_table()
+            .context("envault.toml must be a TOML table")?;
+        let mut mappings = BTreeMap::new();
+        for (k, v) in table {
+            match v.as_str() {
+                Some(alias) => {
+                    mappings.insert(k.clone(), alias.to_string());
+                }
+                None => bail!(
+                    "envault.toml must contain only flat ENV_VAR = \"alias\" pairs (offending key: {k})"
+                ),
+            }
+        }
+        Ok(Manifest {
+            path: path.to_path_buf(),
+            mappings,
+        })
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let mut out = String::from(
+            "# envault manifest: ENV_VAR = \"vault alias\" (names only, no secrets)\n",
+        );
+        for (k, v) in &self.mappings {
+            out.push_str(&format!("{k} = \"{v}\"\n"));
+        }
+        std::fs::write(&self.path, out).with_context(|| format!("writing {}", self.path.display()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn find_walks_up() {
+        let root = TempDir::new().unwrap();
+        std::fs::write(root.path().join(MANIFEST_NAME), "").unwrap();
+        let nested = root.path().join("a/b/c");
+        std::fs::create_dir_all(&nested).unwrap();
+        let found = find_manifest(&nested).unwrap();
+        assert_eq!(found, root.path().join(MANIFEST_NAME));
+        let elsewhere = TempDir::new().unwrap();
+        assert!(find_manifest(elsewhere.path()).is_none());
+    }
+
+    #[test]
+    fn load_save_roundtrip_flat_pairs() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(MANIFEST_NAME);
+        std::fs::write(&path, "OPENROUTER_API_KEY = \"openrouter\"\n").unwrap();
+        let mut m = Manifest::load(&path).unwrap();
+        assert_eq!(m.mappings["OPENROUTER_API_KEY"], "openrouter");
+        m.mappings.insert("OTHER_KEY".into(), "other".into());
+        m.save().unwrap();
+        let re = Manifest::load(&path).unwrap();
+        assert_eq!(re.mappings.len(), 2);
+        assert_eq!(re.mappings["OTHER_KEY"], "other");
+    }
+
+    #[test]
+    fn non_flat_manifest_rejected() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(MANIFEST_NAME);
+        std::fs::write(&path, "[table]\nkey = \"x\"\n").unwrap();
+        let err = Manifest::load(&path).unwrap_err().to_string();
+        assert!(err.contains("flat"), "got: {err}");
+    }
+}

--- a/src/masker.rs
+++ b/src/masker.rs
@@ -1,0 +1,167 @@
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+
+const MIN_MASK_LEN: usize = 6;
+
+pub struct Masker {
+    /// (pattern bytes, replacement bytes), longest pattern first
+    patterns: Vec<(Vec<u8>, Vec<u8>)>,
+    buf: Vec<u8>,
+    holdback: usize,
+}
+
+impl Masker {
+    pub fn new(secrets: &[(String, String)]) -> Masker {
+        let mut patterns: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        for (alias, value) in secrets {
+            if value.len() < MIN_MASK_LEN {
+                continue;
+            }
+            let replacement = format!("[envault:{alias}]").into_bytes();
+            let mut forms = vec![value.clone().into_bytes(), B64.encode(value).into_bytes()];
+            let url = urlencoding::encode(value).into_owned().into_bytes();
+            if url != value.as_bytes() {
+                forms.push(url);
+            }
+            for f in forms {
+                patterns.push((f, replacement.clone()));
+            }
+        }
+        // longest first, so a longer form wins when forms overlap
+        patterns.sort_by_key(|(p, _)| std::cmp::Reverse(p.len()));
+        let holdback = patterns
+            .iter()
+            .map(|(p, _)| p.len())
+            .max()
+            .map_or(0, |m| m - 1);
+        Masker {
+            patterns,
+            buf: Vec::new(),
+            holdback,
+        }
+    }
+
+    /// Replace every full pattern occurrence currently in the buffer.
+    /// Skips past inserted replacement text so replacements are never re-scanned,
+    /// and a pattern can never span the emit boundary because `holdback` is at
+    /// least every pattern length minus one.
+    fn replace_in_buf(&mut self) {
+        let mut i = 0;
+        'outer: while i < self.buf.len() {
+            for pat_idx in 0..self.patterns.len() {
+                let (pat, rep) = &self.patterns[pat_idx];
+                if self.buf[i..].starts_with(pat) {
+                    let rep = rep.clone();
+                    let pat_len = pat.len();
+                    self.buf.splice(i..i + pat_len, rep.iter().copied());
+                    i += rep.len();
+                    continue 'outer;
+                }
+            }
+            i += 1;
+        }
+    }
+
+    pub fn feed(&mut self, chunk: &[u8]) -> Vec<u8> {
+        self.buf.extend_from_slice(chunk);
+        self.replace_in_buf();
+        if self.buf.len() <= self.holdback {
+            return Vec::new();
+        }
+        let emit_len = self.buf.len() - self.holdback;
+        let out: Vec<u8> = self.buf.drain(..emit_len).collect();
+        out
+    }
+
+    pub fn flush(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mask_all(m: &mut Masker, input: &[u8]) -> String {
+        let mut out = m.feed(input);
+        out.extend(m.flush());
+        String::from_utf8(out).unwrap()
+    }
+
+    fn one(alias: &str, value: &str) -> Masker {
+        Masker::new(&[(alias.to_string(), value.to_string())])
+    }
+
+    #[test]
+    fn masks_exact_value() {
+        let mut m = one("openrouter", "sk-or-v1-abc123");
+        assert_eq!(
+            mask_all(&mut m, b"key is sk-or-v1-abc123 ok"),
+            "key is [envault:openrouter] ok"
+        );
+    }
+
+    #[test]
+    fn masks_across_chunk_boundary() {
+        let mut m = one("openrouter", "sk-or-v1-abc123");
+        let mut out = m.feed(b"key is sk-or-v1");
+        out.extend(m.feed(b"-abc123 ok"));
+        out.extend(m.flush());
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "key is [envault:openrouter] ok"
+        );
+    }
+
+    #[test]
+    fn masks_base64_form() {
+        // echo -n 'sk-or-v1-abc123' | base64  ->  c2stb3ItdjEtYWJjMTIz
+        let mut m = one("openrouter", "sk-or-v1-abc123");
+        assert_eq!(
+            mask_all(&mut m, b"b64: c2stb3ItdjEtYWJjMTIz."),
+            "b64: [envault:openrouter]."
+        );
+    }
+
+    #[test]
+    fn masks_url_encoded_form() {
+        let mut m = one("weird", "p@ss word+1");
+        assert_eq!(
+            mask_all(&mut m, b"q=p%40ss%20word%2B1&x=1"),
+            "q=[envault:weird]&x=1"
+        );
+    }
+
+    #[test]
+    fn short_values_not_masked() {
+        let mut m = one("pin", "1234");
+        assert_eq!(mask_all(&mut m, b"pin is 1234"), "pin is 1234");
+    }
+
+    #[test]
+    fn multiple_secrets_and_repeats() {
+        let mut m = Masker::new(&[
+            ("a-key".to_string(), "AAAAAA".to_string()),
+            ("b-key".to_string(), "BBBBBB".to_string()),
+        ]);
+        assert_eq!(
+            mask_all(&mut m, b"AAAAAA BBBBBB AAAAAA"),
+            "[envault:a-key] [envault:b-key] [envault:a-key]"
+        );
+    }
+
+    #[test]
+    fn no_secrets_passthrough_without_holdback() {
+        let mut m = Masker::new(&[]);
+        assert_eq!(m.feed(b"hello"), b"hello".to_vec());
+        assert!(m.flush().is_empty());
+    }
+
+    #[test]
+    fn partial_match_at_eof_is_emitted_by_flush() {
+        let mut m = one("openrouter", "sk-or-v1-abc123");
+        let mut out = m.feed(b"tail sk-or-v1");
+        out.extend(m.flush());
+        assert_eq!(String::from_utf8(out).unwrap(), "tail sk-or-v1");
+    }
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,18 @@
+use std::path::{Path, PathBuf};
+
+pub fn envault_home() -> PathBuf {
+    if let Ok(h) = std::env::var("ENVAULT_HOME") {
+        return PathBuf::from(h);
+    }
+    dirs::home_dir()
+        .expect("no home directory")
+        .join(".envault")
+}
+
+pub fn vault_file(home: &Path) -> PathBuf {
+    home.join("vault.json")
+}
+
+pub fn recipient_file(home: &Path) -> PathBuf {
+    home.join("recipient.txt")
+}

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,18 @@
+//! Small cross-platform helpers so the rest of the code stays platform-clean.
+
+use std::io;
+use std::path::Path;
+
+/// Restrict a file/dir to the current user. On Unix this is a chmod; on other
+/// platforms (Windows) files created under the user profile are already
+/// user-scoped by the default ACLs, so this is a no-op.
+#[cfg(unix)]
+pub fn set_mode(path: &Path, mode: u32) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+}
+
+#[cfg(not(unix))]
+pub fn set_mode(_path: &Path, _mode: u32) -> io::Result<()> {
+    Ok(())
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,64 @@
+//! User-configurable settings, stored at `~/.envault/config.json`.
+//! Changing them is gated (see `commands::config`) so an agent can't silently
+//! disable the audit log or the Touch ID requirement.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct Settings {
+    /// Record every decryption to the audit log.
+    pub audit_log: bool,
+    /// Require a Touch ID / password prompt before each decryption.
+    pub touch_id: bool,
+}
+
+fn config_file(home: &Path) -> std::path::PathBuf {
+    home.join("config.json")
+}
+
+impl Settings {
+    /// Load settings, falling back to defaults if the file is missing or
+    /// unreadable (never fails — settings are best-effort).
+    pub fn load(home: &Path) -> Settings {
+        std::fs::read_to_string(config_file(home))
+            .ok()
+            .and_then(|raw| serde_json::from_str(&raw).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self, home: &Path) -> Result<()> {
+        std::fs::create_dir_all(home)?;
+        let path = config_file(home);
+        std::fs::write(&path, serde_json::to_string_pretty(self)?)
+            .with_context(|| format!("writing {}", path.display()))?;
+        crate::platform::set_mode(&path, 0o600)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn defaults_when_missing() {
+        let home = TempDir::new().unwrap();
+        let s = Settings::load(home.path());
+        assert!(!s.audit_log && !s.touch_id);
+    }
+
+    #[test]
+    fn save_load_roundtrip() {
+        let home = TempDir::new().unwrap();
+        let s = Settings {
+            audit_log: true,
+            touch_id: true,
+        };
+        s.save(home.path()).unwrap();
+        assert_eq!(Settings::load(home.path()), s);
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,141 @@
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+use crate::paths::vault_file;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SecretEntry {
+    pub alias: String,
+    pub label: String,
+    pub cipher: String, // base64 of binary age ciphertext
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub url: Option<String>,
+    pub created_at: String, // RFC3339
+    pub updated_at: String,
+    #[serde(default)]
+    pub notes: String,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct Vault {
+    pub secrets: Vec<SecretEntry>,
+}
+
+impl Vault {
+    pub fn load(home: &Path) -> Result<Vault> {
+        let path = vault_file(home);
+        if !path.exists() {
+            bail!(
+                "no vault found at {} — run `envault init` first",
+                path.display()
+            );
+        }
+        let raw =
+            fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+    }
+
+    pub fn save(&self, home: &Path) -> Result<()> {
+        fs::create_dir_all(home)?;
+        let path = vault_file(home);
+        fs::write(&path, serde_json::to_string_pretty(self)?)?;
+        crate::platform::set_mode(&path, 0o600)?;
+        Ok(())
+    }
+
+    pub fn get(&self, alias: &str) -> Option<&SecretEntry> {
+        self.secrets.iter().find(|s| s.alias == alias)
+    }
+
+    pub fn insert(&mut self, e: SecretEntry) -> Result<()> {
+        if self.get(&e.alias).is_some() {
+            bail!("alias '{}' already exists", e.alias);
+        }
+        self.secrets.push(e);
+        self.secrets.sort_by_key(|s| s.alias.clone());
+        Ok(())
+    }
+}
+
+pub fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+pub fn is_valid_alias(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() || c.is_ascii_digit() => {}
+        _ => return false,
+    }
+    s.chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn entry(alias: &str) -> SecretEntry {
+        SecretEntry {
+            alias: alias.into(),
+            label: format!("{alias} label"),
+            cipher: "Y2lwaGVy".into(),
+            url: None,
+            created_at: now_rfc3339(),
+            updated_at: now_rfc3339(),
+            notes: String::new(),
+        }
+    }
+
+    #[test]
+    fn save_load_roundtrip() {
+        let home = TempDir::new().unwrap();
+        let mut v = Vault::default();
+        v.insert(entry("openrouter")).unwrap();
+        v.save(home.path()).unwrap();
+        let loaded = Vault::load(home.path()).unwrap();
+        assert_eq!(loaded.secrets.len(), 1);
+        assert_eq!(loaded.get("openrouter").unwrap().label, "openrouter label");
+    }
+
+    #[test]
+    fn load_without_vault_mentions_init() {
+        let home = TempDir::new().unwrap();
+        let err = Vault::load(home.path()).unwrap_err().to_string();
+        assert!(err.contains("envault init"), "got: {err}");
+    }
+
+    #[test]
+    fn duplicate_alias_rejected() {
+        let mut v = Vault::default();
+        v.insert(entry("a-key")).unwrap();
+        let err = v.insert(entry("a-key")).unwrap_err().to_string();
+        assert!(err.contains("already exists"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn vault_json_is_mode_600() {
+        use std::os::unix::fs::PermissionsExt;
+        let home = TempDir::new().unwrap();
+        Vault::default().save(home.path()).unwrap();
+        let mode = std::fs::metadata(crate::paths::vault_file(home.path()))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+
+    #[test]
+    fn alias_validation() {
+        assert!(is_valid_alias("openrouter"));
+        assert!(is_valid_alias("my-key-2"));
+        assert!(!is_valid_alias("My-Key"));
+        assert!(!is_valid_alias("-lead"));
+        assert!(!is_valid_alias(""));
+        assert!(!is_valid_alias("has_underscore"));
+    }
+}


### PR DESCRIPTION
Core & CLI of envault (crypto, access gate, masker, guard hook, all `src/commands/*`) as a size-limited diff off an empty base. Run `/ultrareview <this PR #>`.

Focus: crypto/identity handling (`crypto.rs`, `access.rs`), output masking (`masker.rs`), the agent guard (`commands/guard.rs`), and command-construction / OS-window spawning in `commands/request.rs` (shell/AppleScript/PowerShell injection safety). Note: Windows/Linux `#[cfg]` paths are compile-checked only; `biometric.rs` prompt is unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)