### PR TITLE
Review 2/2 — TUI dashboard

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,0 +1,849 @@
+use crossterm::event::{KeyCode, KeyEvent};
+
+use crate::crypto::encrypt_value;
+use crate::store::{is_valid_alias, now_rfc3339, SecretEntry, Vault};
+
+/// Form field order: the two essentials first, optional annotations below.
+pub const FIELD_NAMES: [&str; 5] = ["name", "value", "label", "url", "notes"];
+const NAME: usize = 0;
+const VALUE: usize = 1;
+const LABEL: usize = 2;
+const URL: usize = 3;
+const NOTES: usize = 4;
+
+/// One-line "what is this field" help, shown under the form as you move focus.
+pub const FIELD_HELP: [&str; 5] = [
+    "permanent identifier agents use — locked once created, cannot be renamed",
+    "the secret itself — encrypted at rest, never shown to agents",
+    "optional human label shown in the dashboard",
+    "optional — restricts `envault fill` to this page host (anti-phishing)",
+    "optional free-text notes",
+];
+
+/// Typable `:` commands: (name, description). Also drives the palette list.
+pub const COMMANDS: [(&str, &str); 5] = [
+    ("rotate", "re-key the vault · revokes Keychain grants"),
+    ("help", "keys, commands & the security boundary"),
+    ("quit", "exit the dashboard"),
+    ("audit", "turn the audit log on/off"),
+    ("touchid", "turn the Touch ID gate on/off"),
+];
+
+/// Indices into COMMANDS whose name starts with `input` (empty input = all).
+pub fn command_matches(input: &str) -> Vec<usize> {
+    let q = input.trim().to_lowercase();
+    COMMANDS
+        .iter()
+        .enumerate()
+        .filter(|(_, (name, _))| q.is_empty() || name.starts_with(&q))
+        .map(|(i, _)| i)
+        .collect()
+}
+
+/// The `:` command line plus which palette row is highlighted.
+#[derive(Debug, Clone, Default)]
+pub struct CommandLine {
+    pub input: String,
+    pub sel: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct Form {
+    pub fields: [String; 5],
+    pub focus: usize,
+    pub editing_alias: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum Mode {
+    List,
+    Search,
+    Add(Form),
+    Edit(Form),
+    ConfirmDelete,
+    ConfirmRotate,
+    Reveal(String),
+    Command(CommandLine),
+    Help,
+}
+
+#[derive(Debug)]
+pub enum Effect {
+    Save,
+    Decrypt { alias: String },
+    Copy { alias: String },
+    Rotate,
+    ToggleAudit,
+    ToggleTouchId,
+    Quit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusKind {
+    Info,
+    Success,
+    Error,
+}
+
+pub struct App {
+    pub vault: Vault,
+    pub recipient: age::x25519::Recipient,
+    pub query: String,
+    pub selected: usize,
+    pub mode: Mode,
+    pub status: String,
+    pub status_kind: StatusKind,
+    /// Cached settings for display; the runtime keeps this in sync with disk.
+    pub settings: crate::settings::Settings,
+}
+
+impl App {
+    pub fn new(vault: Vault, recipient: age::x25519::Recipient) -> App {
+        App {
+            vault,
+            recipient,
+            query: String::new(),
+            selected: 0,
+            mode: Mode::List,
+            status: String::new(),
+            status_kind: StatusKind::Info,
+            settings: crate::settings::Settings::default(),
+        }
+    }
+
+    pub fn set_info(&mut self, msg: impl Into<String>) {
+        self.status = msg.into();
+        self.status_kind = StatusKind::Info;
+    }
+
+    pub fn set_success(&mut self, msg: impl Into<String>) {
+        self.status = msg.into();
+        self.status_kind = StatusKind::Success;
+    }
+
+    pub fn set_error(&mut self, msg: impl Into<String>) {
+        self.status = msg.into();
+        self.status_kind = StatusKind::Error;
+    }
+
+    pub fn visible(&self) -> Vec<&SecretEntry> {
+        let q = self.query.to_lowercase();
+        self.vault
+            .secrets
+            .iter()
+            .filter(|s| {
+                q.is_empty()
+                    || s.alias.to_lowercase().contains(&q)
+                    || s.label.to_lowercase().contains(&q)
+            })
+            .collect()
+    }
+
+    pub fn selected_alias(&self) -> Option<String> {
+        self.visible().get(self.selected).map(|e| e.alias.clone())
+    }
+
+    fn clamp_selection(&mut self) {
+        // the add row (index == len) is a valid landing spot
+        let max = self.visible().len();
+        if self.selected > max {
+            self.selected = max;
+        }
+    }
+
+    pub fn provide_plaintext(&mut self, value: String) {
+        self.mode = Mode::Reveal(value);
+    }
+
+    /// Swap in a vault reloaded from disk (e.g. after an external change like a
+    /// granted request), keeping the selection in range. The recipient is
+    /// unchanged — external writers encrypt to the same public key.
+    pub fn reload_vault(&mut self, vault: Vault) {
+        self.vault = vault;
+        self.clamp_selection();
+    }
+
+    /// Runtime callback after a successful `Effect::Rotate`.
+    pub fn after_rotate(&mut self, count: usize, vault: Vault, recipient: age::x25519::Recipient) {
+        self.vault = vault;
+        self.recipient = recipient;
+        self.clamp_selection();
+        self.set_success(format!(
+            "rotated {count} secret(s) · re-grant Always Allow on next use"
+        ));
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> Option<Effect> {
+        match std::mem::replace(&mut self.mode, Mode::List) {
+            Mode::List => self.on_list_key(key),
+            Mode::Search => {
+                self.on_search_key(key);
+                None
+            }
+            Mode::Reveal(_) => None, // any key returns to List
+            Mode::Help => None,      // any key returns to List
+            Mode::ConfirmDelete => self.on_confirm_delete(key),
+            Mode::ConfirmRotate => self.on_confirm_rotate(key),
+            Mode::Command(input) => self.on_command_key(key, input),
+            Mode::Add(form) => self.on_form_key(key, form, false),
+            Mode::Edit(form) => self.on_form_key(key, form, true),
+        }
+    }
+
+    /// Index of the phantom "＋ add" row — one past the last secret.
+    pub fn add_row_index(&self) -> usize {
+        self.visible().len()
+    }
+
+    /// True when the selection is on the phantom add row, not a secret.
+    pub fn on_add_row(&self) -> bool {
+        self.selected >= self.add_row_index()
+    }
+
+    fn open_add(&mut self) {
+        self.mode = Mode::Add(Form {
+            fields: Default::default(),
+            focus: NAME,
+            editing_alias: None,
+        });
+    }
+
+    fn open_edit(&mut self, alias: &str) {
+        let e = self.vault.get(alias).expect("selected exists");
+        self.mode = Mode::Edit(Form {
+            fields: [
+                e.alias.clone(),
+                String::new(), // empty value keeps the old cipher
+                e.label.clone(),
+                e.url.clone().unwrap_or_default(),
+                e.notes.clone(),
+            ],
+            focus: VALUE, // name is locked; start on value
+            editing_alias: Some(alias.to_string()),
+        });
+    }
+
+    fn on_list_key(&mut self, key: KeyEvent) -> Option<Effect> {
+        self.mode = Mode::List;
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => return Some(Effect::Quit),
+            KeyCode::Char('j') | KeyCode::Down => {
+                // stop on the add row (index == len), never past it
+                if self.selected < self.add_row_index() {
+                    self.selected += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.selected = self.selected.saturating_sub(1);
+            }
+            KeyCode::Char('/') => {
+                self.query.clear();
+                self.mode = Mode::Search;
+            }
+            KeyCode::Char('?') => {
+                self.mode = Mode::Help;
+            }
+            KeyCode::Char(':') => {
+                self.mode = Mode::Command(CommandLine::default());
+            }
+            KeyCode::Char('a') => self.open_add(),
+            // Enter / → activate the highlighted row: edit a secret, or add.
+            KeyCode::Enter | KeyCode::Right => match self.selected_alias() {
+                Some(alias) => self.open_edit(&alias),
+                None => self.open_add(),
+            },
+            KeyCode::Char('e') => {
+                if let Some(alias) = self.selected_alias() {
+                    self.open_edit(&alias);
+                }
+            }
+            KeyCode::Char('d') => {
+                if self.selected_alias().is_some() {
+                    self.mode = Mode::ConfirmDelete;
+                }
+            }
+            KeyCode::Char('r') => {
+                if let Some(alias) = self.selected_alias() {
+                    return Some(Effect::Decrypt { alias });
+                }
+            }
+            KeyCode::Char('c') => {
+                if let Some(alias) = self.selected_alias() {
+                    return Some(Effect::Copy { alias });
+                }
+            }
+            KeyCode::Char(c) if ('1'..='9').contains(&c) => {
+                let idx = (c as usize) - ('1' as usize);
+                if idx < self.visible().len() {
+                    self.selected = idx;
+                }
+            }
+            _ => {}
+        }
+        None
+    }
+
+    fn on_search_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Enter => {
+                self.mode = Mode::List;
+                self.selected = 0;
+                self.clamp_selection();
+            }
+            KeyCode::Esc => {
+                self.query.clear();
+                self.mode = Mode::List;
+                self.clamp_selection();
+            }
+            KeyCode::Backspace => {
+                self.query.pop();
+                self.mode = Mode::Search;
+            }
+            KeyCode::Char(c) => {
+                self.query.push(c);
+                self.mode = Mode::Search;
+            }
+            _ => self.mode = Mode::Search,
+        }
+    }
+
+    fn on_confirm_delete(&mut self, key: KeyEvent) -> Option<Effect> {
+        self.mode = Mode::List;
+        if let KeyCode::Char('y') = key.code {
+            if let Some(alias) = self.selected_alias() {
+                self.vault.secrets.retain(|s| s.alias != alias);
+                self.clamp_selection();
+                self.set_success(format!("deleted '{alias}'"));
+                return Some(Effect::Save);
+            }
+        }
+        None
+    }
+
+    fn on_confirm_rotate(&mut self, key: KeyEvent) -> Option<Effect> {
+        self.mode = Mode::List;
+        if let KeyCode::Char('y') = key.code {
+            self.set_info("rotating keypair…");
+            return Some(Effect::Rotate);
+        }
+        self.set_info("cancelled");
+        None
+    }
+
+    fn on_command_key(&mut self, key: KeyEvent, mut cl: CommandLine) -> Option<Effect> {
+        let matches = command_matches(&cl.input);
+        match key.code {
+            KeyCode::Esc => {
+                self.mode = Mode::List;
+            }
+            KeyCode::Up => {
+                cl.sel = cl.sel.saturating_sub(1);
+                self.mode = Mode::Command(cl);
+            }
+            KeyCode::Down => {
+                if !matches.is_empty() {
+                    cl.sel = (cl.sel + 1).min(matches.len() - 1);
+                }
+                self.mode = Mode::Command(cl);
+            }
+            KeyCode::Tab => {
+                // autocomplete the input to the highlighted command
+                if let Some(&idx) = matches.get(cl.sel) {
+                    cl.input = COMMANDS[idx].0.to_string();
+                    cl.sel = 0;
+                }
+                self.mode = Mode::Command(cl);
+            }
+            KeyCode::Enter => {
+                self.mode = Mode::List;
+                // exact typed match wins; otherwise run the highlighted row
+                let typed = cl.input.trim().to_lowercase();
+                let target = if COMMANDS.iter().any(|(n, _)| *n == typed) {
+                    Some(typed)
+                } else {
+                    matches.get(cl.sel).map(|&idx| COMMANDS[idx].0.to_string())
+                };
+                return match target {
+                    Some(cmd) => self.run_command(&cmd),
+                    None => {
+                        self.set_error(format!("unknown command: {}", cl.input.trim()));
+                        None
+                    }
+                };
+            }
+            KeyCode::Backspace => {
+                if cl.input.pop().is_none() {
+                    self.mode = Mode::List; // backspace on empty exits
+                } else {
+                    cl.sel = 0;
+                    self.mode = Mode::Command(cl);
+                }
+            }
+            KeyCode::Char(c) => {
+                cl.input.push(c);
+                cl.sel = 0;
+                self.mode = Mode::Command(cl);
+            }
+            _ => self.mode = Mode::Command(cl),
+        }
+        None
+    }
+
+    fn run_command(&mut self, cmd: &str) -> Option<Effect> {
+        match cmd {
+            "" => {}
+            "rotate" => self.mode = Mode::ConfirmRotate,
+            "help" | "?" => self.mode = Mode::Help,
+            "audit" => return Some(Effect::ToggleAudit),
+            "touchid" | "touch-id" => return Some(Effect::ToggleTouchId),
+            "q" | "quit" | "exit" => return Some(Effect::Quit),
+            other => {
+                self.set_error(format!("unknown command: {other}"));
+            }
+        }
+        None
+    }
+
+    fn on_form_key(&mut self, key: KeyEvent, mut form: Form, editing: bool) -> Option<Effect> {
+        match key.code {
+            KeyCode::Esc => {
+                self.mode = Mode::List;
+                self.set_info("cancelled");
+                return None;
+            }
+            KeyCode::Tab | KeyCode::Down => {
+                form.focus = (form.focus + 1) % form.fields.len();
+                if editing && form.focus == NAME {
+                    form.focus = VALUE;
+                }
+            }
+            KeyCode::BackTab | KeyCode::Up => {
+                form.focus = (form.focus + form.fields.len() - 1) % form.fields.len();
+                if editing && form.focus == NAME {
+                    form.focus = form.fields.len() - 1;
+                }
+            }
+            KeyCode::Backspace => {
+                form.fields[form.focus].pop();
+            }
+            KeyCode::Char(c) => {
+                form.fields[form.focus].push(c);
+            }
+            KeyCode::Enter => return self.submit_form(form, editing),
+            _ => {}
+        }
+        self.mode = if editing {
+            Mode::Edit(form)
+        } else {
+            Mode::Add(form)
+        };
+        None
+    }
+
+    fn submit_form(&mut self, form: Form, editing: bool) -> Option<Effect> {
+        let name = form.fields[NAME].clone();
+        let value = form.fields[VALUE].clone();
+        let label = form.fields[LABEL].clone();
+        let url = form.fields[URL].clone();
+        let notes = form.fields[NOTES].clone();
+        if editing {
+            let target = form.editing_alias.clone().expect("edit has name");
+            let cipher = if value.is_empty() {
+                None
+            } else {
+                match encrypt_value(&self.recipient, &value) {
+                    Ok(c) => Some(c),
+                    Err(e) => {
+                        self.set_error(format!("encryption failed: {e}"));
+                        self.mode = Mode::Edit(form);
+                        return None;
+                    }
+                }
+            };
+            if let Some(entry) = self.vault.secrets.iter_mut().find(|s| s.alias == target) {
+                entry.label = if label.is_empty() {
+                    target.clone()
+                } else {
+                    label
+                };
+                entry.url = if url.is_empty() { None } else { Some(url) };
+                entry.notes = notes;
+                if let Some(c) = cipher {
+                    entry.cipher = c;
+                }
+                entry.updated_at = now_rfc3339();
+            }
+            self.set_success(format!("updated '{target}'"));
+            self.mode = Mode::List;
+            return Some(Effect::Save);
+        }
+        // Add
+        if !is_valid_alias(&name) {
+            self.set_error("name must be kebab-case: lowercase letters, digits, '-'");
+            self.mode = Mode::Add(form);
+            return None;
+        }
+        if self.vault.get(&name).is_some() {
+            self.set_error(format!("name '{name}' already exists"));
+            self.mode = Mode::Add(form);
+            return None;
+        }
+        if value.is_empty() {
+            self.set_error("value must not be empty");
+            self.mode = Mode::Add(form);
+            return None;
+        }
+        let cipher = match encrypt_value(&self.recipient, &value) {
+            Ok(c) => c,
+            Err(e) => {
+                self.set_error(format!("encryption failed: {e}"));
+                self.mode = Mode::Add(form);
+                return None;
+            }
+        };
+        let now = now_rfc3339();
+        self.vault
+            .insert(SecretEntry {
+                label: if label.is_empty() {
+                    name.clone()
+                } else {
+                    label
+                },
+                alias: name.clone(),
+                cipher,
+                url: if url.is_empty() { None } else { Some(url) },
+                created_at: now.clone(),
+                updated_at: now,
+                notes,
+            })
+            .ok();
+        self.set_success(format!("added '{name}'"));
+        self.mode = Mode::List;
+        Some(Effect::Save)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::{decrypt_value, encrypt_value, generate_identity};
+    use crate::store::{SecretEntry, Vault};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+    fn ch(c: char) -> KeyEvent {
+        key(KeyCode::Char(c))
+    }
+    fn type_str(app: &mut App, s: &str) {
+        for c in s.chars() {
+            app.handle_key(ch(c));
+        }
+    }
+
+    fn entry(alias: &str, recipient: &age::x25519::Recipient) -> SecretEntry {
+        SecretEntry {
+            alias: alias.into(),
+            label: format!("{alias} label"),
+            cipher: encrypt_value(recipient, "old-value-123").unwrap(),
+            url: None,
+            created_at: crate::store::now_rfc3339(),
+            updated_at: crate::store::now_rfc3339(),
+            notes: String::new(),
+        }
+    }
+
+    fn app_with(aliases: &[&str]) -> (App, age::x25519::Identity) {
+        let id = generate_identity();
+        let recipient = id.to_public();
+        let mut vault = Vault::default();
+        for a in aliases {
+            vault.insert(entry(a, &recipient)).unwrap();
+        }
+        (App::new(vault, recipient), id)
+    }
+
+    #[test]
+    fn navigation_moves_selection() {
+        let (mut app, _) = app_with(&["a-key", "b-key", "c-key"]);
+        assert_eq!(app.selected_alias().as_deref(), Some("a-key"));
+        app.handle_key(ch('j'));
+        assert_eq!(app.selected_alias().as_deref(), Some("b-key"));
+        app.handle_key(ch('k'));
+        assert_eq!(app.selected_alias().as_deref(), Some("a-key"));
+        app.handle_key(ch('k')); // clamped at top
+        assert_eq!(app.selected_alias().as_deref(), Some("a-key"));
+    }
+
+    #[test]
+    fn search_filters_visible() {
+        let (mut app, _) = app_with(&["openrouter", "db-password"]);
+        app.handle_key(ch('/'));
+        type_str(&mut app, "open");
+        app.handle_key(key(KeyCode::Enter));
+        let visible: Vec<_> = app.visible().iter().map(|e| e.alias.clone()).collect();
+        assert_eq!(visible, vec!["openrouter"]);
+        assert_eq!(app.selected_alias().as_deref(), Some("openrouter"));
+    }
+
+    #[test]
+    fn reload_vault_swaps_and_clamps_selection() {
+        let (mut app, id) = app_with(&["a-key", "b-key", "c-key"]);
+        app.selected = 3; // on the add row
+        let mut v = Vault::default();
+        v.insert(entry("only", &id.to_public())).unwrap();
+        app.reload_vault(v);
+        assert_eq!(app.vault.secrets.len(), 1);
+        assert_eq!(app.selected, 1, "selection clamped to the new add row");
+        assert_eq!(app.selected_alias(), None); // add row
+    }
+
+    #[test]
+    fn esc_quits_from_list_like_q() {
+        let (mut app, _) = app_with(&["a-key"]);
+        assert!(matches!(
+            app.handle_key(key(KeyCode::Esc)),
+            Some(Effect::Quit)
+        ));
+    }
+
+    #[test]
+    fn quit_reveal_copy_effects() {
+        let (mut app, _) = app_with(&["a-key"]);
+        assert!(matches!(
+            app.handle_key(ch('r')),
+            Some(Effect::Decrypt { .. })
+        ));
+        app.provide_plaintext("old-value-123".into());
+        assert!(matches!(app.mode, Mode::Reveal(ref v) if v == "old-value-123"));
+        app.handle_key(key(KeyCode::Esc)); // any key leaves reveal
+        assert!(matches!(app.mode, Mode::List));
+        assert!(matches!(app.handle_key(ch('c')), Some(Effect::Copy { .. })));
+        assert!(matches!(app.handle_key(ch('q')), Some(Effect::Quit)));
+    }
+
+    #[test]
+    fn add_flow_encrypts_and_saves() {
+        let (mut app, id) = app_with(&[]);
+        app.handle_key(ch('a'));
+        type_str(&mut app, "new-key"); // name field (0)
+        app.handle_key(key(KeyCode::Tab)); // value (1)
+        type_str(&mut app, "fresh-value-77");
+        app.handle_key(key(KeyCode::Tab)); // label (2)
+        type_str(&mut app, "New Key");
+        let eff = app.handle_key(key(KeyCode::Enter));
+        assert!(matches!(eff, Some(Effect::Save)));
+        let entry = app.vault.get("new-key").expect("entry added");
+        assert_eq!(entry.label, "New Key");
+        assert_eq!(decrypt_value(&id, &entry.cipher).unwrap(), "fresh-value-77");
+    }
+
+    #[test]
+    fn add_rejects_bad_alias_and_empty_value() {
+        let (mut app, _) = app_with(&[]);
+        app.handle_key(ch('a'));
+        type_str(&mut app, "Bad Alias");
+        assert!(app.handle_key(key(KeyCode::Enter)).is_none());
+        assert!(matches!(app.mode, Mode::Add(_)), "stays in form");
+        assert!(app.status.contains("kebab-case"), "status: {}", app.status);
+    }
+
+    #[test]
+    fn edit_keeps_cipher_when_value_empty() {
+        let (mut app, id) = app_with(&["a-key"]);
+        let old_cipher = app.vault.get("a-key").unwrap().cipher.clone();
+        app.handle_key(ch('e'));
+        // edit form opens focused on value (1); name is locked
+        app.handle_key(key(KeyCode::Tab)); // label (2)
+        type_str(&mut app, "!"); // append to label
+        let eff = app.handle_key(key(KeyCode::Enter));
+        assert!(matches!(eff, Some(Effect::Save)));
+        let entry = app.vault.get("a-key").unwrap();
+        assert_eq!(entry.cipher, old_cipher);
+        assert!(entry.label.ends_with('!'));
+        assert_eq!(decrypt_value(&id, &entry.cipher).unwrap(), "old-value-123");
+    }
+
+    #[test]
+    fn edit_never_reaches_locked_name_field() {
+        let (mut app, _) = app_with(&["a-key"]);
+        app.handle_key(ch('e'));
+        // BackTab from value (1) wraps to notes (4), skipping name (0)
+        app.handle_key(key(KeyCode::BackTab));
+        let Mode::Edit(form) = &app.mode else {
+            panic!("expected edit mode")
+        };
+        assert_eq!(form.focus, 4);
+        // Tab from notes (4) skips name (0) and lands on value (1)
+        app.handle_key(key(KeyCode::Tab));
+        let Mode::Edit(form) = &app.mode else {
+            panic!("expected edit mode")
+        };
+        assert_eq!(form.focus, 1);
+    }
+
+    #[test]
+    fn right_arrow_opens_edit_on_a_secret() {
+        let (mut app, _) = app_with(&["a-key"]);
+        app.handle_key(key(KeyCode::Right));
+        assert!(matches!(app.mode, Mode::Edit(_)), "→ opens edit");
+    }
+
+    #[test]
+    fn add_row_sits_below_last_and_activates_add() {
+        let (mut app, _) = app_with(&["a-key", "b-key"]);
+        // down past the last secret lands on the phantom "add" row
+        app.handle_key(ch('j'));
+        app.handle_key(ch('j'));
+        assert_eq!(app.selected, 2, "add row is index == len");
+        assert!(app.selected_alias().is_none(), "add row is not a secret");
+        // Enter (or →) on the add row opens the add form
+        app.handle_key(key(KeyCode::Enter));
+        assert!(matches!(app.mode, Mode::Add(_)), "Enter on add row adds");
+    }
+
+    #[test]
+    fn add_row_is_the_only_row_when_empty() {
+        let (mut app, _) = app_with(&[]);
+        assert_eq!(app.selected, 0);
+        assert!(app.selected_alias().is_none());
+        app.handle_key(key(KeyCode::Right));
+        assert!(matches!(app.mode, Mode::Add(_)), "→ on empty adds");
+    }
+
+    #[test]
+    fn enter_on_a_secret_opens_edit() {
+        let (mut app, _) = app_with(&["a-key"]);
+        app.handle_key(key(KeyCode::Enter));
+        assert!(matches!(app.mode, Mode::Edit(_)));
+    }
+
+    #[test]
+    fn number_keys_jump_selection() {
+        let (mut app, _) = app_with(&["a-key", "b-key", "c-key"]);
+        app.handle_key(ch('3'));
+        assert_eq!(app.selected_alias().as_deref(), Some("c-key"));
+        app.handle_key(ch('1'));
+        assert_eq!(app.selected_alias().as_deref(), Some("a-key"));
+        app.handle_key(ch('9')); // out of range: no move
+        assert_eq!(app.selected_alias().as_deref(), Some("a-key"));
+    }
+
+    #[test]
+    fn help_opens_and_any_key_closes() {
+        let (mut app, _) = app_with(&["a-key"]);
+        app.handle_key(ch('?'));
+        assert!(matches!(app.mode, Mode::Help));
+        app.handle_key(ch('x'));
+        assert!(matches!(app.mode, Mode::List));
+    }
+
+    #[test]
+    fn command_mode_rotate_flow() {
+        let (mut app, _) = app_with(&["a-key"]);
+        app.handle_key(ch(':'));
+        type_str(&mut app, "rotate");
+        assert!(app.handle_key(key(KeyCode::Enter)).is_none());
+        assert!(matches!(app.mode, Mode::ConfirmRotate));
+        let eff = app.handle_key(ch('y'));
+        assert!(matches!(eff, Some(Effect::Rotate)));
+
+        // 'n' cancels the confirm
+        app.handle_key(ch(':'));
+        type_str(&mut app, "rotate");
+        app.handle_key(key(KeyCode::Enter));
+        assert!(app.handle_key(ch('n')).is_none());
+        assert!(matches!(app.mode, Mode::List));
+    }
+
+    #[test]
+    fn command_palette_filters_and_arrows_select() {
+        let (mut app, _) = app_with(&[]);
+        app.handle_key(ch(':'));
+        type_str(&mut app, "h"); // matches only "help"
+        let matches = command_matches("h");
+        assert_eq!(matches, vec![1]);
+        // Enter with a single match runs it (help)
+        assert!(app.handle_key(key(KeyCode::Enter)).is_none());
+        assert!(matches!(app.mode, Mode::Help));
+    }
+
+    #[test]
+    fn command_palette_enter_runs_highlighted_on_empty_input() {
+        let (mut app, _) = app_with(&[]);
+        app.handle_key(ch(':')); // empty input, sel 0 = rotate
+        assert!(app.handle_key(key(KeyCode::Enter)).is_none());
+        assert!(matches!(app.mode, Mode::ConfirmRotate));
+    }
+
+    #[test]
+    fn command_palette_down_then_enter_picks_second() {
+        let (mut app, _) = app_with(&[]);
+        app.handle_key(ch(':'));
+        app.handle_key(key(KeyCode::Down)); // sel 1 = help
+        assert!(app.handle_key(key(KeyCode::Enter)).is_none());
+        assert!(matches!(app.mode, Mode::Help));
+    }
+
+    #[test]
+    fn command_palette_toggles_settings() {
+        let (mut app, _) = app_with(&[]);
+        app.handle_key(ch(':'));
+        type_str(&mut app, "audit");
+        assert!(matches!(
+            app.handle_key(key(KeyCode::Enter)),
+            Some(Effect::ToggleAudit)
+        ));
+        app.handle_key(ch(':'));
+        type_str(&mut app, "touchid");
+        assert!(matches!(
+            app.handle_key(key(KeyCode::Enter)),
+            Some(Effect::ToggleTouchId)
+        ));
+    }
+
+    #[test]
+    fn command_tab_autocompletes_highlighted() {
+        let (mut app, _) = app_with(&[]);
+        app.handle_key(ch(':'));
+        type_str(&mut app, "q");
+        app.handle_key(key(KeyCode::Tab));
+        let Mode::Command(cl) = &app.mode else {
+            panic!("expected command mode")
+        };
+        assert_eq!(cl.input, "quit");
+    }
+
+    #[test]
+    fn command_mode_quit_unknown_and_escape() {
+        let (mut app, _) = app_with(&[]);
+        app.handle_key(ch(':'));
+        type_str(&mut app, "quit");
+        assert!(matches!(
+            app.handle_key(key(KeyCode::Enter)),
+            Some(Effect::Quit)
+        ));
+
+        app.handle_key(ch(':'));
+        type_str(&mut app, "bogus");
+        assert!(app.handle_key(key(KeyCode::Enter)).is_none());
+        assert!(matches!(app.status_kind, StatusKind::Error));
+        assert!(app.status.contains("unknown command"), "{}", app.status);
+
+        app.handle_key(ch(':'));
+        app.handle_key(key(KeyCode::Esc));
+        assert!(matches!(app.mode, Mode::List));
+    }
+
+    #[test]
+    fn after_rotate_swaps_key_material_and_reports() {
+        let (mut app, _) = app_with(&["a-key"]);
+        let new_id = generate_identity();
+        let new_vault = Vault::default();
+        app.after_rotate(1, new_vault, new_id.to_public());
+        assert!(matches!(app.status_kind, StatusKind::Success));
+        assert!(app.status.contains("rotated 1"), "{}", app.status);
+        assert!(app.vault.secrets.is_empty());
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,0 +1,177 @@
+pub mod app;
+pub mod request;
+pub mod theme;
+pub mod ui;
+
+use anyhow::{bail, Context, Result};
+use crossterm::event::{self, Event};
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
+use std::io::{IsTerminal, Write};
+
+use crate::crypto;
+use crate::paths;
+use crate::store::Vault;
+use app::{App, Effect};
+
+pub fn run_tui() -> Result<()> {
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        bail!(
+            "the envault dashboard needs an interactive terminal (agents: use `envault ls --json`)"
+        );
+    }
+    let home = paths::envault_home();
+    if !paths::vault_file(&home).exists() {
+        print!("No vault at {} — initialize now? [y/N] ", home.display());
+        std::io::stdout().flush()?;
+        let mut line = String::new();
+        std::io::stdin().read_line(&mut line)?;
+        if line.trim().eq_ignore_ascii_case("y") {
+            crate::commands::init::cmd_init()?;
+        } else {
+            bail!("no vault — nothing to show");
+        }
+    }
+    let vault = Vault::load(&home)?;
+    let recipient = crypto::load_recipient(&home)?;
+    let mut app = App::new(vault, recipient);
+
+    crossterm::terminal::enable_raw_mode()?;
+    crossterm::execute!(std::io::stdout(), crossterm::terminal::EnterAlternateScreen)?;
+    let result = event_loop(&mut app, &home);
+    crossterm::execute!(std::io::stdout(), crossterm::terminal::LeaveAlternateScreen).ok();
+    crossterm::terminal::disable_raw_mode().ok();
+    result
+}
+
+fn vault_mtime(home: &std::path::Path) -> Option<std::time::SystemTime> {
+    std::fs::metadata(crate::paths::vault_file(home))
+        .and_then(|m| m.modified())
+        .ok()
+}
+
+fn event_loop(app: &mut App, home: &std::path::Path) -> Result<()> {
+    let mut terminal = Terminal::new(CrosstermBackend::new(std::io::stdout()))?;
+    let mut last_mtime = vault_mtime(home);
+    app.settings = crate::settings::Settings::load(home);
+
+    // Read input on a dedicated thread and deliver it over a channel. This lets
+    // the main loop wake on a real timer (recv_timeout) to watch the vault file,
+    // independent of any terminal-specific quirks in crossterm's own poll().
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        while let Ok(ev) = event::read() {
+            if tx.send(ev).is_err() {
+                break;
+            }
+        }
+    });
+
+    loop {
+        // Watch the vault file for external changes (e.g. a granted
+        // `envault request` while this is open).
+        let now = vault_mtime(home);
+        if now != last_mtime {
+            // Only commit the new mtime once the load actually succeeds, so a
+            // read that lands mid-write (partial JSON) is retried next tick.
+            if let Ok(v) = Vault::load(home) {
+                last_mtime = now;
+                app.reload_vault(v);
+                app.set_info("vault updated");
+            }
+        }
+
+        terminal.draw(|f| ui::draw(f, app))?;
+
+        // Wait for input, but wake at least twice a second to re-check the file.
+        let key = match rx.recv_timeout(std::time::Duration::from_millis(500)) {
+            Ok(Event::Key(k)) => k,
+            Ok(_) => continue, // resize/focus/etc.
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return Ok(()),
+        };
+        if key.kind != event::KeyEventKind::Press {
+            continue;
+        }
+        let effect = app.handle_key(key);
+        match effect {
+            None => {}
+            Some(Effect::Quit) => return Ok(()),
+            Some(Effect::Save) => {
+                if let Err(e) = app.vault.save(home) {
+                    app.set_error(format!("save failed: {e:#}"));
+                }
+            }
+            Some(Effect::Decrypt { alias }) => match decrypt(app, home, "reveal", &alias) {
+                Ok(value) => app.provide_plaintext(value),
+                Err(e) => app.set_error(format!("decrypt failed: {e:#}")),
+            },
+            Some(Effect::Copy { alias }) => match decrypt(app, home, "copy", &alias) {
+                Ok(value) => match copy_with_autoclear(value) {
+                    Ok(()) => {
+                        app.set_success(format!("'{alias}' copied — clipboard clears in 15s"));
+                    }
+                    Err(e) => app.set_error(format!("clipboard failed: {e:#}")),
+                },
+                Err(e) => app.set_error(format!("decrypt failed: {e:#}")),
+            },
+            Some(Effect::Rotate) => match crate::commands::rotate::rotate_in_place(home) {
+                Ok(outcome) => match Vault::load(home) {
+                    Ok(v) => app.after_rotate(outcome.count, v, outcome.recipient),
+                    Err(e) => app.set_error(format!("vault reload failed: {e:#}")),
+                },
+                Err(e) => app.set_error(format!("rotate failed: {e:#}")),
+            },
+            // Toggling a setting is always gated — including here in the
+            // dashboard — so turning the audit log off (or on) requires the
+            // system prompt, not just being at the keyboard.
+            Some(Effect::ToggleAudit) => match crate::biometric::require("Change the envault audit log setting") {
+                Ok(()) => {
+                    app.settings.audit_log = !app.settings.audit_log;
+                    persist_settings(app, home, "audit log");
+                }
+                Err(e) => app.set_error(format!("not changed: {e:#}")),
+            },
+            Some(Effect::ToggleTouchId) => match crate::biometric::require("Change the envault Touch ID setting") {
+                Ok(()) => {
+                    app.settings.touch_id = !app.settings.touch_id;
+                    persist_settings(app, home, "Touch ID gate");
+                }
+                Err(e) => app.set_error(format!("not changed: {e:#}")),
+            },
+        }
+        // Our own writes (save/rotate) just changed the file; adopt the new
+        // mtime so the watcher above doesn't treat them as an external change.
+        last_mtime = vault_mtime(home);
+    }
+}
+
+fn persist_settings(app: &mut App, home: &std::path::Path, label: &str) {
+    let state = if label.contains("audit") {
+        app.settings.audit_log
+    } else {
+        app.settings.touch_id
+    };
+    match app.settings.save(home) {
+        Ok(()) => app.set_success(format!("{label} {}", if state { "on" } else { "off" })),
+        Err(e) => app.set_error(format!("couldn't save settings: {e:#}")),
+    }
+}
+
+fn decrypt(app: &App, home: &std::path::Path, action: &str, alias: &str) -> Result<String> {
+    let entry = app.vault.get(alias).context("entry vanished")?.clone();
+    let identity = crate::access::unlock(home, action, alias)?;
+    crypto::decrypt_value(&identity, &entry.cipher)
+}
+
+fn copy_with_autoclear(value: String) -> Result<()> {
+    let mut cb = arboard::Clipboard::new().context("opening clipboard")?;
+    cb.set_text(value)?;
+    std::thread::spawn(|| {
+        std::thread::sleep(std::time::Duration::from_secs(15));
+        if let Ok(mut cb) = arboard::Clipboard::new() {
+            cb.set_text(String::new()).ok();
+        }
+    });
+    Ok(())
+}

--- a/src/tui/request.rs
+++ b/src/tui/request.rs
@@ -1,0 +1,341 @@
+//! The request window: a stripped-down, single-purpose screen an agent pops
+//! when it needs a secret it doesn't have. The human grants (pastes a value)
+//! or declines (with a note back to the agent). The agent never sees the value.
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::theme::{ACCENT, DIM, DOTS, ERR, KEYCAP, OK};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph, Wrap};
+use ratatui::Frame;
+
+/// What the agent asked for (read-only in the window).
+#[derive(Debug, Clone)]
+pub struct RequestMeta {
+    pub name: String,
+    pub label: String,
+    pub reason: String,
+    /// Identity the agent claimed via `--agent` (or a default).
+    pub agent: String,
+    /// The real calling process, for cross-checking the claim.
+    pub caller: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    Granted(String),  // the pasted value
+    Declined(String), // a note back to the agent
+    Cancelled,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Field {
+    Value,
+    Note,
+}
+
+pub struct RequestApp {
+    pub meta: RequestMeta,
+    pub value: String,
+    pub note: String,
+    field: Field,
+}
+
+impl RequestApp {
+    pub fn new(meta: RequestMeta) -> RequestApp {
+        RequestApp {
+            meta,
+            value: String::new(),
+            note: String::new(),
+            field: Field::Value,
+        }
+    }
+
+    pub fn declining(&self) -> bool {
+        self.field == Field::Note
+    }
+
+    /// Returns Some(outcome) when the window should close.
+    pub fn handle_key(&mut self, key: KeyEvent) -> Option<Outcome> {
+        match self.field {
+            Field::Value => match key.code {
+                KeyCode::Esc => return Some(Outcome::Cancelled),
+                KeyCode::Enter => {
+                    if !self.value.is_empty() {
+                        return Some(Outcome::Granted(self.value.clone()));
+                    }
+                }
+                // `n` decides to decline — but only when the value box is still
+                // empty, so it can't hijack a key that begins with 'n'.
+                KeyCode::Char('n') if self.value.is_empty() => {
+                    self.field = Field::Note;
+                }
+                KeyCode::Char(c) => self.value.push(c),
+                KeyCode::Backspace => {
+                    self.value.pop();
+                }
+                _ => {}
+            },
+            Field::Note => match key.code {
+                KeyCode::Esc => self.field = Field::Value, // back to the value box
+                KeyCode::Enter => return Some(Outcome::Declined(self.note.clone())),
+                KeyCode::Char(c) => self.note.push(c),
+                KeyCode::Backspace => {
+                    self.note.pop();
+                }
+                _ => {}
+            },
+        }
+        None
+    }
+}
+
+pub fn draw(frame: &mut Frame, app: &RequestApp) {
+    let area = centered(frame.area(), 72, 20);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(ACCENT))
+        .title(Span::styled(
+            " envault · secret request ",
+            Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(3), Constraint::Length(2)])
+        .split(inner);
+
+    let m = &app.meta;
+    let field = |k: &str| Span::styled(format!("  {k:<13}"), Style::default().fg(DIM));
+    let mut lines = vec![
+        Line::styled(
+            "  An agent is asking you to add a secret.",
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Line::from(""),
+        Line::from(vec![
+            field("requested by"),
+            Span::styled(m.agent.clone(), Style::default().fg(KEYCAP)),
+        ]),
+        Line::from(vec![
+            field("process"),
+            Span::styled(m.caller.clone(), Style::default().fg(DIM)),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            field("name"),
+            Span::styled(
+                m.name.clone(),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![field("label"), Span::raw(disp(&m.label))]),
+        Line::from(vec![field("reason"), Span::raw(disp(&m.reason))]),
+        Line::from(""),
+    ];
+
+    if app.declining() {
+        lines.push(Line::styled(
+            "  Declining — add a note for the agent (optional):",
+            Style::default().fg(ERR),
+        ));
+        lines.push(Line::from(vec![
+            field("note"),
+            Span::raw(app.note.clone()),
+            Span::styled("▏", Style::default().fg(ACCENT)),
+        ]));
+        lines.push(Line::styled(
+            "                press Enter to decline (with or without a note)",
+            Style::default().fg(DIM),
+        ));
+    } else {
+        let dots = "•".repeat(app.value.chars().count());
+        lines.push(Line::from(vec![
+            field("value"),
+            Span::styled("▌", Style::default().fg(ACCENT)),
+            Span::styled(dots, Style::default().fg(DOTS)),
+            Span::styled(
+                format!("  ({} chars)", app.value.chars().count()),
+                Style::default().fg(DIM),
+            ),
+        ]));
+        lines.push(Line::styled(
+            "                paste the key here, then press Enter",
+            Style::default().fg(DIM),
+        ));
+    }
+
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), rows[0]);
+
+    // Two-line footer: key hints, then the reassurance on its own line so it
+    // is never clipped by the window edge.
+    let footer = if app.declining() {
+        vec![
+            Line::from(vec![
+                keycap("Enter"),
+                Span::styled(" send note & close   ", Style::default().fg(DIM)),
+                keycap("Esc"),
+                Span::styled(" back to value", Style::default().fg(DIM)),
+            ]),
+            Line::styled(
+                "  the agent sees only your note — never a value.",
+                Style::default().fg(OK),
+            ),
+        ]
+    } else {
+        vec![
+            Line::from(vec![
+                keycap("Enter"),
+                Span::styled(" grant & close   ", Style::default().fg(DIM)),
+                keycap("n"),
+                Span::styled(" decline   ", Style::default().fg(DIM)),
+                keycap("Esc"),
+                Span::styled(" cancel", Style::default().fg(DIM)),
+            ]),
+            Line::styled(
+                "  the agent never sees the value you paste.",
+                Style::default().fg(OK),
+            ),
+        ]
+    };
+    frame.render_widget(Paragraph::new(footer), rows[1]);
+}
+
+fn keycap(k: &str) -> Span<'static> {
+    Span::styled(
+        k.to_string(),
+        Style::default().fg(KEYCAP).add_modifier(Modifier::BOLD),
+    )
+}
+
+fn disp(s: &str) -> String {
+    if s.is_empty() {
+        "—".into()
+    } else {
+        s.to_string()
+    }
+}
+
+fn centered(area: Rect, w: u16, h: u16) -> Rect {
+    let w = w.min(area.width);
+    let h = h.min(area.height);
+    Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn meta() -> RequestMeta {
+        RequestMeta {
+            name: "openrouter".into(),
+            label: "OpenRouter API key".into(),
+            reason: "needed to call OpenRouter for summaries".into(),
+            agent: "Claude Code".into(),
+            caller: "node (pid 4242)".into(),
+        }
+    }
+    fn key(c: KeyCode) -> KeyEvent {
+        KeyEvent::new(c, KeyModifiers::NONE)
+    }
+    fn ch(c: char) -> KeyEvent {
+        key(KeyCode::Char(c))
+    }
+    fn typ(app: &mut RequestApp, s: &str) {
+        for c in s.chars() {
+            app.handle_key(ch(c));
+        }
+    }
+
+    #[test]
+    fn paste_and_enter_grants() {
+        let mut app = RequestApp::new(meta());
+        typ(&mut app, "sk-or-v1-xyz");
+        assert_eq!(
+            app.handle_key(key(KeyCode::Enter)),
+            Some(Outcome::Granted("sk-or-v1-xyz".into()))
+        );
+    }
+
+    #[test]
+    fn empty_enter_does_nothing() {
+        let mut app = RequestApp::new(meta());
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), None);
+    }
+
+    #[test]
+    fn n_on_empty_starts_decline_then_note_sends() {
+        let mut app = RequestApp::new(meta());
+        assert_eq!(app.handle_key(ch('n')), None);
+        assert!(app.declining());
+        typ(&mut app, "use OpenAI instead");
+        assert_eq!(
+            app.handle_key(key(KeyCode::Enter)),
+            Some(Outcome::Declined("use OpenAI instead".into()))
+        );
+    }
+
+    #[test]
+    fn decline_with_empty_note_is_allowed() {
+        let mut app = RequestApp::new(meta());
+        app.handle_key(ch('n')); // into decline
+        assert!(app.declining());
+        // press Enter immediately, no note typed
+        assert_eq!(
+            app.handle_key(key(KeyCode::Enter)),
+            Some(Outcome::Declined(String::new()))
+        );
+    }
+
+    #[test]
+    fn n_after_typing_is_a_value_char_not_decline() {
+        let mut app = RequestApp::new(meta());
+        typ(&mut app, "abc"); // value now non-empty
+        app.handle_key(ch('n'));
+        assert!(!app.declining(), "n must be literal once value has content");
+        assert_eq!(app.value, "abcn");
+    }
+
+    #[test]
+    fn esc_cancels_and_esc_in_note_returns() {
+        let mut app = RequestApp::new(meta());
+        app.handle_key(ch('n')); // into note
+        app.handle_key(key(KeyCode::Esc)); // back to value
+        assert!(!app.declining());
+        assert_eq!(app.handle_key(key(KeyCode::Esc)), Some(Outcome::Cancelled));
+    }
+
+    #[test]
+    fn renders_agent_name_and_masks_value() {
+        let mut app = RequestApp::new(meta());
+        typ(&mut app, "secret123");
+        let mut t = Terminal::new(TestBackend::new(90, 26)).unwrap();
+        t.draw(|f| draw(f, &app)).unwrap();
+        let buf = t.backend().buffer();
+        let area = *buf.area();
+        let mut text = String::new();
+        for y in 0..area.height {
+            for x in 0..area.width {
+                text.push_str(buf.cell((x, y)).unwrap().symbol());
+            }
+            text.push('\n');
+        }
+        assert!(text.contains("Claude Code"), "shows agent: {text}");
+        assert!(text.contains("openrouter"), "shows name: {text}");
+        assert!(text.contains("reason"), "shows reason label: {text}");
+        assert!(!text.contains("secret123"), "value must be masked: {text}");
+        assert!(text.contains("•"), "masked dots: {text}");
+    }
+}

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,0 +1,11 @@
+//! Shared adaptive ANSI palette — resolves against the user's terminal theme,
+//! so both the main dashboard and the request window look like one tool.
+
+use ratatui::style::Color;
+
+pub const ACCENT: Color = Color::Cyan;
+pub const KEYCAP: Color = Color::Yellow;
+pub const DIM: Color = Color::DarkGray;
+pub const OK: Color = Color::Green;
+pub const ERR: Color = Color::Red;
+pub const DOTS: Color = Color::Yellow;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,0 +1,846 @@
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph, Wrap};
+use ratatui::Frame;
+
+use super::app::{App, Mode, StatusKind, COMMANDS, FIELD_NAMES};
+use super::theme::{ACCENT, DIM, DOTS, ERR, KEYCAP, OK};
+
+// Big block wordmark ("envault"), colored + filled.
+const BANNER: &str = r#"
+ ███████ ███    ██ ██    ██  █████  ██    ██ ██    ████████
+ ██      ████   ██ ██    ██ ██   ██ ██    ██ ██       ██
+ █████   ██ ██  ██ ██    ██ ███████ ██    ██ ██       ██
+ ██      ██  ██ ██  ██  ██  ██   ██ ██    ██ ██       ██
+ ███████ ██   ████   ████   ██   ██  ██████  ███████  ██
+"#;
+
+pub fn draw(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+    // Banner only when there's comfortable vertical room.
+    let banner_h: u16 = if area.height >= 20 { 7 } else { 0 };
+
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(banner_h),
+            Constraint::Min(3),
+            Constraint::Length(1), // footer key-guide
+            Constraint::Length(1), // status / command line
+        ])
+        .split(area);
+
+    if banner_h > 0 {
+        draw_banner(frame, outer[0], app);
+    }
+
+    let main = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(38), Constraint::Percentage(62)])
+        .split(outer[1]);
+
+    draw_list(frame, main[0], app);
+    draw_details(frame, main[1], app);
+    draw_footer(frame, outer[2], app);
+    draw_status(frame, outer[3], app);
+
+    // Overlays paint on top.
+    match &app.mode {
+        Mode::Help => draw_help_overlay(frame, area, app),
+        Mode::Command(cl) => draw_command_palette(frame, outer[3], &cl.input, cl.sel),
+        Mode::ConfirmDelete => draw_confirm_popup(
+            frame,
+            area,
+            "Delete this secret?",
+            &format!(
+                "'{}' will be removed permanently. This cannot be undone.",
+                app.selected_alias().unwrap_or_default()
+            ),
+        ),
+        Mode::ConfirmRotate => draw_confirm_popup(
+            frame,
+            area,
+            "Rotate the vault keypair?",
+            "Re-encrypts every secret to a fresh key and revokes every \
+             Keychain grant — macOS will ask you to Always Allow again.",
+        ),
+        _ => {}
+    }
+}
+
+/// Command palette: a small list of `:` commands, filtered by what's typed,
+/// floating just above the command line, with the highlighted row marked.
+fn draw_command_palette(frame: &mut Frame, cmdline_area: Rect, input: &str, sel: usize) {
+    let matches = crate::tui::app::command_matches(input);
+    if matches.is_empty() {
+        return;
+    }
+    let rows = matches.len() as u16;
+    let height = rows + 2; // borders
+    let width: u16 = 60;
+    // sit directly above the command line
+    let y = cmdline_area.y.saturating_sub(height);
+    let x = cmdline_area.x;
+    let area = Rect {
+        x,
+        y,
+        width: width.min(cmdline_area.width),
+        height,
+    };
+    frame.render_widget(Clear, area);
+    let items: Vec<ListItem> = matches
+        .iter()
+        .enumerate()
+        .map(|(row, &idx)| {
+            let (name, desc) = COMMANDS[idx];
+            let selected = row == sel;
+            let marker = if selected { "▌" } else { " " };
+            let name_style = if selected {
+                Style::default().fg(ACCENT).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().add_modifier(Modifier::BOLD)
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(marker, Style::default().fg(ACCENT)),
+                Span::styled(format!(":{name:<8}"), name_style),
+                Span::styled(desc.to_string(), Style::default().fg(DIM)),
+            ]))
+        })
+        .collect();
+    frame.render_widget(
+        List::new(items).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(ACCENT))
+                .title(Span::styled(
+                    " commands ",
+                    Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+                )),
+        ),
+        area,
+    );
+}
+
+fn draw_banner(frame: &mut Frame, area: Rect, app: &App) {
+    let mut lines: Vec<Line> = BANNER
+        .lines()
+        .skip(1) // leading newline
+        .map(|l| {
+            Line::styled(
+                l.to_string(),
+                Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+            )
+        })
+        .collect();
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!(" {} secrets", app.vault.secrets.len()),
+            Style::default().fg(ACCENT),
+        ),
+        Span::styled("  ~/.envault", Style::default().fg(DIM)),
+    ]));
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn draw_list(frame: &mut Frame, area: Rect, app: &App) {
+    let visible = app.visible();
+    let searching = matches!(app.mode, Mode::Search);
+    let title = if searching || !app.query.is_empty() {
+        Line::from(vec![
+            Span::styled(" search: ", Style::default().fg(DIM)),
+            Span::styled(app.query.clone(), Style::default().fg(KEYCAP)),
+            Span::styled(" ", Style::default()),
+        ])
+    } else {
+        Line::styled(
+            " secrets ",
+            Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+        )
+    };
+
+    let mut items: Vec<ListItem> = visible
+        .iter()
+        .enumerate()
+        .map(|(i, e)| {
+            let selected = i == app.selected;
+            let bar = if selected { "▌" } else { " " };
+            let num = i + 1;
+            let mut spans = vec![
+                Span::styled(bar, Style::default().fg(ACCENT)),
+                Span::styled(
+                    format!("{num} "),
+                    Style::default().fg(if selected { KEYCAP } else { DIM }),
+                ),
+            ];
+            let name_style = if selected {
+                Style::default().add_modifier(Modifier::BOLD).fg(ACCENT)
+            } else {
+                Style::default().add_modifier(Modifier::BOLD)
+            };
+            spans.push(Span::styled(e.alias.clone(), name_style));
+            ListItem::new(Line::from(spans))
+        })
+        .collect();
+
+    // The "＋ add new secret" row sits below the last secret and is selectable.
+    let add_selected = app.on_add_row();
+    let add_bar = if add_selected { "▌" } else { " " };
+    let add_style = if add_selected {
+        Style::default().fg(ACCENT).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(DIM)
+    };
+    items.push(ListItem::new(Line::from(vec![
+        Span::styled(add_bar, Style::default().fg(ACCENT)),
+        Span::styled("＋ ", Style::default().fg(KEYCAP)),
+        Span::styled("add new secret", add_style),
+    ])));
+
+    let border = if searching { KEYCAP } else { ACCENT };
+    let list = List::new(items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(border))
+            .title(title),
+    );
+    frame.render_widget(list, area);
+}
+
+fn draw_details(frame: &mut Frame, area: Rect, app: &App) {
+    let (title, lines): (String, Vec<Line>) = match &app.mode {
+        Mode::Add(form) | Mode::Edit(form) => {
+            let editing = matches!(app.mode, Mode::Edit(_));
+            let title = if editing {
+                " edit ".into()
+            } else {
+                " add ".into()
+            };
+            let mut lines = vec![Line::styled(
+                if editing {
+                    "Enter save · Esc cancel · empty value keeps old"
+                } else {
+                    "Enter save · Esc cancel · Tab next field"
+                },
+                Style::default().fg(DIM),
+            )];
+            for (i, fname) in FIELD_NAMES.iter().enumerate() {
+                if i == LABEL {
+                    lines.push(Line::styled("─ optional ─", Style::default().fg(DIM)));
+                }
+                let focused = form.focus == i;
+                let marker = if focused { "▌" } else { " " };
+                let shown = if i == VALUE_IDX {
+                    "•".repeat(form.fields[i].len())
+                } else {
+                    form.fields[i].clone()
+                };
+                let key_style = if focused {
+                    Style::default().fg(ACCENT).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(DIM)
+                };
+                let mut spans = vec![
+                    Span::styled(marker, Style::default().fg(ACCENT)),
+                    Span::styled(format!("{fname:<7}"), key_style),
+                    Span::raw(shown),
+                ];
+                if i == NAME_IDX {
+                    let tag = if editing {
+                        "  (locked — names can't change)"
+                    } else {
+                        "  (permanent)"
+                    };
+                    spans.push(Span::styled(tag, Style::default().fg(DIM)));
+                }
+                lines.push(Line::from(spans));
+            }
+            // "information session": explain the focused field.
+            lines.push(Line::from(""));
+            lines.push(Line::from(vec![
+                Span::styled("ℹ ", Style::default().fg(ACCENT)),
+                Span::styled(
+                    crate::tui::app::FIELD_HELP[form.focus],
+                    Style::default().fg(DIM),
+                ),
+            ]));
+            if form.focus == NAME_IDX && !editing {
+                lines.push(Line::styled(
+                    "  the name is locked once created — choose it carefully.",
+                    Style::default().fg(KEYCAP),
+                ));
+            }
+            (title, lines)
+        }
+        _ => detail_view(app),
+    };
+
+    let para = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(DIM))
+                .title(Span::styled(
+                    title,
+                    Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+                )),
+        )
+        .wrap(Wrap { trim: false });
+    frame.render_widget(para, area);
+}
+
+const NAME_IDX: usize = 0;
+const VALUE_IDX: usize = 1;
+const LABEL: usize = 2;
+
+fn detail_view(app: &App) -> (String, Vec<Line<'static>>) {
+    let Some(alias) = app.selected_alias() else {
+        // The add row is selected (or the vault is empty).
+        let headline = if app.vault.secrets.is_empty() {
+            "No secrets yet."
+        } else {
+            "Add a new secret."
+        };
+        return (
+            " add ".into(),
+            vec![
+                Line::styled(headline, Style::default().add_modifier(Modifier::BOLD)),
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("Press ", Style::default().fg(DIM)),
+                    Span::styled(
+                        "Enter",
+                        Style::default().fg(KEYCAP).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(" or ", Style::default().fg(DIM)),
+                    Span::styled(
+                        "→",
+                        Style::default().fg(KEYCAP).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(" to add — the agent-facing", Style::default().fg(DIM)),
+                ]),
+                Line::styled(
+                    "way is `envault request` (a request window).",
+                    Style::default().fg(DIM),
+                ),
+            ],
+        );
+    };
+    let e = app.vault.get(&alias).expect("selected exists");
+    let field = |k: &str| Span::styled(format!("{k:<8}"), Style::default().fg(DIM));
+
+    // name, then value directly below.
+    let mut lines = vec![Line::from(vec![
+        field("name"),
+        Span::styled(
+            e.alias.clone(),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+    ])];
+
+    if let Mode::Reveal(value) = &app.mode {
+        lines.push(Line::from(vec![
+            field("value"),
+            Span::styled(
+                value.clone(),
+                Style::default().fg(KEYCAP).add_modifier(Modifier::BOLD),
+            ),
+        ]));
+        lines.push(Line::styled(
+            "         (any key to hide)",
+            Style::default().fg(DIM),
+        ));
+    } else {
+        lines.push(Line::from(vec![
+            field("value"),
+            Span::styled("••••••••", Style::default().fg(DOTS)),
+            Span::styled("  age-encrypted", Style::default().fg(DIM)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::raw("         "),
+            Span::styled("r", Style::default().fg(KEYCAP)),
+            Span::styled(" reveal · ", Style::default().fg(DIM)),
+            Span::styled("c", Style::default().fg(KEYCAP)),
+            Span::styled(" copy (15s)", Style::default().fg(DIM)),
+        ]));
+    }
+
+    lines.push(Line::styled("─ optional ─", Style::default().fg(DIM)));
+    lines.push(Line::from(vec![
+        field("label"),
+        Span::raw(if e.label.is_empty() {
+            "—".into()
+        } else {
+            e.label.clone()
+        }),
+    ]));
+    let mut url_spans = vec![
+        field("url"),
+        Span::raw(match &e.url {
+            Some(u) => u.clone(),
+            None => "—".into(),
+        }),
+    ];
+    if e.url.is_some() {
+        url_spans.push(Span::styled("  ✓ guarded", Style::default().fg(OK)));
+    }
+    lines.push(Line::from(url_spans));
+    lines.push(Line::from(vec![
+        field("notes"),
+        Span::raw(if e.notes.is_empty() {
+            "—".into()
+        } else {
+            e.notes.clone()
+        }),
+    ]));
+    lines.push(Line::from(vec![
+        field("time"),
+        Span::styled(
+            format!(
+                "created {} · updated {}",
+                rel_time(&e.created_at),
+                rel_time(&e.updated_at)
+            ),
+            Style::default().fg(DIM),
+        ),
+    ]));
+    (" details ".into(), lines)
+}
+
+fn draw_footer(frame: &mut Frame, area: Rect, app: &App) {
+    let hint = |k: &str, label: &str| {
+        vec![
+            Span::styled(
+                k.to_string(),
+                Style::default().fg(KEYCAP).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(format!(" {label}  "), Style::default().fg(DIM)),
+        ]
+    };
+    let mut spans = Vec::new();
+    match app.mode {
+        Mode::Search => {
+            spans.extend(hint("type", "filter"));
+            spans.extend(hint("Enter", "apply"));
+            spans.extend(hint("Esc", "clear"));
+        }
+        Mode::Add(_) | Mode::Edit(_) => {
+            spans.extend(hint("Tab", "next"));
+            spans.extend(hint("Enter", "save"));
+            spans.extend(hint("Esc", "cancel"));
+        }
+        Mode::Command(_) => {
+            spans.extend(hint("↑↓", "pick"));
+            spans.extend(hint("Tab", "complete"));
+            spans.extend(hint("Enter", "run"));
+            spans.extend(hint("Esc", "cancel"));
+        }
+        _ => {
+            spans.extend(hint("↑↓", "move"));
+            spans.extend(hint("/", "search"));
+            spans.extend(hint("a", "add"));
+            spans.extend(hint("e", "edit"));
+            spans.extend(hint("d", "del"));
+            spans.extend(hint(":", "cmd"));
+            spans.extend(hint("?", "help"));
+        }
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn draw_status(frame: &mut Frame, area: Rect, app: &App) {
+    if let Mode::Command(cl) = &app.mode {
+        let line = Line::from(vec![
+            Span::styled(
+                ":",
+                Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(cl.input.clone()),
+            Span::styled("_", Style::default().fg(ACCENT)),
+        ]);
+        frame.render_widget(Paragraph::new(line), area);
+        return;
+    }
+    let color = match app.status_kind {
+        StatusKind::Info => DIM,
+        StatusKind::Success => OK,
+        StatusKind::Error => ERR,
+    };
+    let prefix = match app.status_kind {
+        StatusKind::Success => "✔ ",
+        StatusKind::Error => "✖ ",
+        StatusKind::Info => "",
+    };
+    frame.render_widget(
+        Paragraph::new(Line::styled(
+            format!("{prefix}{}", app.status),
+            Style::default().fg(color),
+        ))
+        .alignment(Alignment::Right),
+        area,
+    );
+}
+
+fn draw_confirm_popup(frame: &mut Frame, area: Rect, title: &str, body: &str) {
+    // Wide enough for the body, and text wraps so nothing is ever clipped.
+    let popup = centered_rect(area, 62, 9);
+    frame.render_widget(Clear, popup);
+    let lines = vec![
+        Line::from(""),
+        Line::styled(format!("  {body}"), Style::default().fg(DIM)),
+        Line::from(""),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("y", Style::default().fg(OK).add_modifier(Modifier::BOLD)),
+            Span::styled(" yes     ", Style::default().fg(DIM)),
+            Span::styled("n", Style::default().fg(ERR).add_modifier(Modifier::BOLD)),
+            Span::styled(" / any other key  no", Style::default().fg(DIM)),
+        ]),
+    ];
+    frame.render_widget(
+        Paragraph::new(lines).wrap(Wrap { trim: true }).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(ERR))
+                .title(Span::styled(
+                    format!(" {title} "),
+                    Style::default().fg(ERR).add_modifier(Modifier::BOLD),
+                )),
+        ),
+        popup,
+    );
+}
+
+fn draw_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let popup = centered_rect(area, 66, 26);
+    frame.render_widget(Clear, popup);
+    let key = |k: &str, d: &str| {
+        Line::from(vec![
+            Span::styled(
+                format!("  {k:<10}"),
+                Style::default().fg(KEYCAP).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(d.to_string(), Style::default().fg(DIM)),
+        ])
+    };
+    let head = |t: &str| {
+        Line::styled(
+            format!("  {t}"),
+            Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+        )
+    };
+    let lines = vec![
+        head("Keys"),
+        key("↑ / ↓ j k", "move selection"),
+        key("1-9", "jump to secret"),
+        key("/", "search"),
+        key("a / e / d", "add · edit · delete"),
+        key("r / c", "reveal · copy (clears in 15s)"),
+        Line::from(""),
+        head("Commands  (: opens a searchable palette)"),
+        key(":rotate", "re-key the vault (revokes Keychain grants)"),
+        key(
+            ":audit",
+            &format!("audit log — now {}", on_off(app.settings.audit_log)),
+        ),
+        key(
+            ":touchid",
+            &format!("Touch ID gate — now {}", on_off(app.settings.touch_id)),
+        ),
+        key(":help / :quit", "this screen · exit"),
+        Line::from(""),
+        head("What agents can see"),
+        Line::styled(
+            "  Protected: values never enter an agent's context, files, or",
+            Style::default().fg(OK),
+        ),
+        Line::styled(
+            "  logs. Agents get names + ciphers only; run output is masked.",
+            Style::default().fg(OK),
+        ),
+        Line::styled(
+            "  Bypassed: a process YOU launch via `envault run` holds the",
+            Style::default().fg(ERR),
+        ),
+        Line::styled(
+            "  real value and could leak it over the network or to a file;",
+            Style::default().fg(ERR),
+        ),
+        Line::styled(
+            "  masking only covers its stdout. :rotate revokes old trust.",
+            Style::default().fg(ERR),
+        ),
+        Line::from(""),
+        Line::styled("  Press any key to close.", Style::default().fg(DIM)),
+    ];
+    frame.render_widget(
+        Paragraph::new(lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(ACCENT))
+                .title(Span::styled(
+                    " help & security ",
+                    Style::default().fg(ACCENT).add_modifier(Modifier::BOLD),
+                )),
+        ),
+        popup,
+    );
+}
+
+fn on_off(b: bool) -> &'static str {
+    if b {
+        "ON"
+    } else {
+        "off"
+    }
+}
+
+fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
+    let w = width.min(area.width);
+    let h = height.min(area.height);
+    Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    }
+}
+
+/// Coarse "Nd ago" / "Nh ago" from an RFC3339 timestamp. Falls back to the
+/// raw date on parse failure — never panics.
+fn rel_time(ts: &str) -> String {
+    let parsed = chrono::DateTime::parse_from_rfc3339(ts);
+    let Ok(then) = parsed else {
+        return ts.split('T').next().unwrap_or(ts).to_string();
+    };
+    let secs = (chrono::Utc::now() - then.with_timezone(&chrono::Utc)).num_seconds();
+    if secs < 0 {
+        return "just now".into();
+    }
+    match secs as u64 {
+        0..=59 => "just now".into(),
+        s @ 60..=3599 => format!("{}m ago", s / 60),
+        s @ 3600..=86399 => format!("{}h ago", s / 3600),
+        s => format!("{}d ago", s / 86400),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::generate_identity;
+    use crate::store::{SecretEntry, Vault};
+    use crate::tui::app::{App, Mode};
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+        let buf = terminal.backend().buffer();
+        let area = *buf.area();
+        let mut out = String::new();
+        for y in 0..area.height {
+            for x in 0..area.width {
+                out.push_str(buf.cell((x, y)).unwrap().symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    fn test_app() -> App {
+        let id = generate_identity();
+        let recipient = id.to_public();
+        let mut vault = Vault::default();
+        vault
+            .insert(SecretEntry {
+                alias: "openrouter".into(),
+                label: "OpenRouter key".into(),
+                cipher: "AAAA".into(),
+                url: Some("https://openrouter.ai".into()),
+                created_at: "2026-08-26T00:00:00Z".into(),
+                updated_at: "2026-08-26T00:00:00Z".into(),
+                notes: String::new(),
+            })
+            .unwrap();
+        App::new(vault, recipient)
+    }
+
+    fn render(app: &App) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        terminal.draw(|f| draw(f, app)).unwrap();
+        buffer_text(&terminal)
+    }
+
+    fn render_sized(app: &App, w: u16, h: u16) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+        terminal.draw(|f| draw(f, app)).unwrap();
+        buffer_text(&terminal)
+    }
+
+    #[test]
+    fn list_numbers_names_and_hides_value() {
+        let app = test_app();
+        let text = render(&app);
+        assert!(text.contains("openrouter"), "{text}");
+        assert!(text.contains("1 openrouter"), "numbered list: {text}");
+        assert!(text.contains("••••"), "value must render hidden: {text}");
+        // "name" is the human label now, not "alias"
+        assert!(text.contains("name"), "{text}");
+        assert!(
+            !text.contains("alias"),
+            "human UI must not say 'alias': {text}"
+        );
+    }
+
+    #[test]
+    fn banner_and_guarded_badge_and_relative_time() {
+        let text = render(&test_app());
+        // ASCII banner present (block glyphs) and guarded badge on the URL row
+        assert!(text.contains('█'), "banner glyphs expected: {text}");
+        assert!(text.contains("guarded"), "url guard badge: {text}");
+        assert!(text.contains("ago"), "relative timestamp: {text}");
+    }
+
+    #[test]
+    fn value_row_is_directly_below_name() {
+        let text = render(&test_app());
+        let lines: Vec<&str> = text.lines().collect();
+        let name_row = lines.iter().position(|l| l.contains("name")).unwrap();
+        let value_row = lines.iter().position(|l| l.contains("value")).unwrap();
+        assert_eq!(value_row, name_row + 1, "value must sit right below name");
+        // optional annotations come after the value
+        let label_row = lines.iter().position(|l| l.contains("label")).unwrap();
+        assert!(label_row > value_row, "annotations below value");
+    }
+
+    #[test]
+    fn reveal_shows_plaintext() {
+        let mut app = test_app();
+        app.mode = Mode::Reveal("sk-or-plaintext-1".into());
+        let text = render(&app);
+        assert!(text.contains("sk-or-plaintext-1"), "{text}");
+    }
+
+    #[test]
+    fn add_form_shows_fields_in_order() {
+        let mut app = test_app();
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('a'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        let text = render(&app);
+        for f in crate::tui::app::FIELD_NAMES {
+            assert!(text.contains(f), "form must show field '{f}': {text}");
+        }
+        let lines: Vec<&str> = text.lines().collect();
+        let name_row = lines.iter().position(|l| l.contains("name")).unwrap();
+        let value_row = lines.iter().position(|l| l.contains("value")).unwrap();
+        let label_row = lines.iter().position(|l| l.contains("label")).unwrap();
+        assert!(
+            name_row < value_row && value_row < label_row,
+            "field order: {text}"
+        );
+    }
+
+    #[test]
+    fn help_overlay_lists_keys_commands_and_bypass() {
+        let mut app = test_app();
+        app.mode = Mode::Help;
+        let text = render(&app);
+        assert!(text.contains("reveal"), "{text}");
+        assert!(text.contains(":rotate"), "commands listed: {text}");
+        assert!(
+            text.contains("never") || text.contains("aliases"),
+            "agent explainer present: {text}"
+        );
+        // the honest "what's bypassed" boundary must be surfaced
+        assert!(text.contains("Bypassed"), "bypass section: {text}");
+        assert!(
+            text.contains("network") || text.contains("leak"),
+            "bypass explains exfiltration: {text}"
+        );
+    }
+
+    #[test]
+    fn command_palette_lists_commands_with_descriptions() {
+        use crate::tui::app::CommandLine;
+        let mut app = test_app();
+        app.mode = Mode::Command(CommandLine {
+            input: "r".into(),
+            sel: 0,
+        });
+        let text = render(&app);
+        assert!(text.contains(":r"), "command prompt shown: {text}");
+        assert!(text.contains("rotate"), "palette lists rotate: {text}");
+        assert!(
+            text.contains("revokes"),
+            "palette shows description: {text}"
+        );
+    }
+
+    #[test]
+    fn add_form_explains_name_is_locked() {
+        let mut app = test_app();
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('a'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        let text = render(&app);
+        // focus starts on name → its help line warns about permanence
+        assert!(
+            text.contains("locked once created") || text.contains("cannot be renamed"),
+            "name-locked notice: {text}"
+        );
+    }
+
+    #[test]
+    fn list_shows_add_row_below_secrets() {
+        let text = render(&test_app());
+        let lines: Vec<&str> = text.lines().collect();
+        let secret_row = lines.iter().position(|l| l.contains("openrouter")).unwrap();
+        let add_row = lines
+            .iter()
+            .position(|l| l.contains("add new secret"))
+            .expect("add row present");
+        assert!(
+            add_row > secret_row,
+            "add row sits below the secrets: {text}"
+        );
+    }
+
+    #[test]
+    fn rotate_popup_text_not_truncated() {
+        let mut app = test_app();
+        app.mode = Mode::ConfirmRotate;
+        let text = render(&app);
+        // the full sentence must appear un-clipped (wrapping allowed)
+        assert!(text.contains("Re-encrypts"), "{text}");
+        assert!(
+            text.contains("revokes") && text.contains("Keychain"),
+            "rotate body must show completely: {text}"
+        );
+    }
+
+    #[test]
+    fn empty_vault_onboards() {
+        let id = generate_identity();
+        let app = App::new(Vault::default(), id.to_public());
+        let text = render(&app);
+        assert!(
+            text.contains("No secrets yet"),
+            "onboarding headline: {text}"
+        );
+        assert!(text.contains("add new secret"), "add row present: {text}");
+    }
+
+    #[test]
+    fn narrow_terminal_hides_banner_but_still_renders() {
+        // banner auto-hides under 30 rows / narrow width; list still shows
+        let text = render_sized(&test_app(), 60, 12);
+        assert!(text.contains("openrouter"), "{text}");
+    }
+}


### PR DESCRIPTION
The ratatui dashboard (`src/tui/*`) as a size-limited diff off an empty base. Run `/ultrareview <this PR #>`.

Focus: the state machine (`tui/app.rs`), rendering (`tui/ui.rs`), the request-window screen (`tui/request.rs`), and the event loop + file-watch + settings gating in `tui/mod.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)